### PR TITLE
Release lucidadl 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,38 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-09-03
+
 ### Added
 - Downloading a playlist now writes an `.m3u8` sidecar inside `Playlists/<name>/`,
   listing its tracks in order. Music players and hardware devices (Garmin watches, car
   units, phones) only show a real *playlist* when such a file is present — a bare folder
   of tracks isn't one. Entries are relative filenames, so the folder stays portable.
+- `lucida doctor --live` explicitly runs the browser and network check when needed.
+
+### Changed
+- The interactive menu groups everyday downloads and maintenance tools into clearer
+  sections, with a guided first-run setup and visible access status.
+- `lucida setup` now installs the matching Playwright Chromium build when it is missing,
+  so the recommended pipx installation no longer needs a separate Playwright command.
+- `lucida doctor` is now a quick local check by default and never opens a browser unless
+  `--live` is supplied.
+- Failed albums and tracks keep their original type, so `lucida retry` no longer retries
+  an album as if it were a song. Download commands also return a failing exit status when
+  work remains, which makes scheduled runs reliable.
+- Missing matches and failed requested transcodes are now reported as failures rather
+  than successful skips/downloads; the original audio is kept if conversion fails.
+- Automatic `artist - title` matching rejects weak or ambiguous results instead of
+  silently downloading a likely-wrong song.
+- Playlist import now clearly supports Apple Music only; unused, unvalidated stubs for
+  other services were removed.
+- The former “watchlists” are now presented for what they are: one-off batch downloads
+  from any `.txt` file. The TUI asks for a file and never edits it; the existing
+  `lucida tracks` and `lucida albums` commands remain compatible.
+- The TUI now ends downloads with a compact success/skip/failure summary. Missing batch
+  files and interactive-search failures also return useful messages and non-zero exit
+  statuses, while cancelling a search remains successful.
+- Developer diagnostics remain available but no longer clutter the main command list.
 
 ## [1.0.0] - 2026-06-28
 
@@ -63,7 +90,8 @@ First public release.
 - **Fixed, configurable download directory** (`~/Downloads/music` by default;
   `lucida config --music`, or the `LUCIDADL_MUSIC` env var).
 
-[Unreleased]: https://github.com/Jude-A/lucidadl/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/Jude-A/lucidadl/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/Jude-A/lucidadl/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/Jude-A/lucidadl/compare/v0.1.1...v1.0.0
 [0.1.1]: https://github.com/Jude-A/lucidadl/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/Jude-A/lucidadl/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ python -m venv .venv
 # Windows:  .venv\Scripts\activate
 # Unix:     source .venv/bin/activate
 pip install -e ".[dev]"      # editable install + build/twine
-playwright install chromium  # one-time, only needed to run the live browser flow
+python -m playwright install chromium  # one-time for the live browser flow
 ```
 
 `pip install -e .` makes the `lucida` / `lucidadl` commands point at your working copy,

--- a/README.md
+++ b/README.md
@@ -2,275 +2,256 @@
 
 [![PyPI](https://img.shields.io/pypi/v/lucidadl.svg)](https://pypi.org/project/lucidadl/)
 [![CI](https://github.com/Jude-A/lucidadl/actions/workflows/ci.yml/badge.svg)](https://github.com/Jude-A/lucidadl/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Python versions](https://img.shields.io/pypi/pyversions/lucidadl.svg)](https://pypi.org/project/lucidadl/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-Fast, parallel command-line music downloader for [lucida.to](https://lucida.to) — fetch
-tracks, albums and playlists from **Qobuz** and **Amazon Music** in lossless **FLAC** (or
-transcode to MP3 / AAC / Opus), neatly organized by tags. Like `yt-dlp`, but for lucida —
-with an interactive terminal UI on top.
+A small, fast music downloader for [lucida.to](https://lucida.to), with both direct
+commands and an interactive terminal interface.
 
-**A vibe-coded project.** lucidadl was built quickly and AI-assisted ("vibe coding"). It
-wraps and automates downloading from [lucida.to](https://lucida.to) — inspired by two
-existing open-source lucida downloaders we looked at (see [Credits](#credits)) and adding
-the features I wanted on top: parallel downloads, local transcoding, tag-based
-organization, playlist import, existence-aware dedup, and an interactive menu.
+lucidadl downloads tracks and albums in parallel, organizes them from their metadata,
+can convert them locally with ffmpeg, accepts large `.txt` batches, and imports public
+Apple Music playlists. It intentionally remains a lightweight personal tool rather than
+a music-library platform.
 
-> **Disclaimer.** This is a personal-use tool, similar in spirit to `yt-dlp`. You are
-> responsible for complying with the terms of service of lucida.to and of the source
-> services, and with the copyright law of your jurisdiction. The authors are not
-> affiliated with lucida.to or any streaming service. Use it for content you are
-> entitled to download.
+> Use lucidadl only for content you are entitled to download. You are responsible for
+> complying with applicable law and with the terms of the services involved. This
+> project is not affiliated with lucida.to, Apple, Qobuz, Amazon, or any streaming
+> service.
 
-## Features
+## Highlights
 
-- **Search or URL** — `track "artist - title"`, `album "artist - album"`, or paste a
-  Qobuz/Amazon URL.
-- **Parallel downloads** over HTTP (`--jobs N`) — no browser kept open, low RAM.
-- **Albums = track by track**, expanded and downloaded in parallel (faster than the
-  native album zip).
-- **Local transcoding** with ffmpeg (`--to mp3 --bitrate 320k`) — bundled, nothing to
-  install. Tags and cover art preserved.
-- **Tag-based organization** into `Artists/<Artist>/<Album>/…` (falls back to the
-  source's artist/album metadata when a file has no embedded tags, so nothing lands in
-  "Unknown"); playlists go under `Playlists/<name>/`, kept separate from artists.
-- **Watchlists** with dedup (`tracks` / `albums` read a file, skip what's done — but a
-  file you deleted is re-downloaded; `--force` ignores the memory entirely).
-- **Playlist import** — paste a playlist link and get every track via lucida. Apple
-  Music is wired up today; adding more sources is easy (PRs welcome).
-- **Interactive search**, **service fallback** (Qobuz → Amazon), **retry** of failures.
-- **Interactive menu** (`lucida ui`, or just `lucida`) and **live progress bars** — one
-  bar per parallel download, in any real terminal.
-
-## Demo
-
-Run `lucida` with no arguments for the interactive menu:
-
-```text
-lucidadl  ·  8 concurrent downloads · qobuz · → flac
-~/Downloads/music
-
-► What do you want to do?  (↑/↓, Enter)
-  🎵  Download a track
-  💿  Download an album
-  🅰️   Import an Apple Music playlist
-  🔎  Interactive search
-  📜  Watchlists (tracks / albums)
-  ⚙   Settings
-  🚪  Quit
-```
-
-…or go straight to a command and watch one progress bar per parallel download:
-
-```text
-$ lucida album "Red Hot Chili Peppers - Californication" --to flac -j 8
-
-  ✓ Californication/Around the World.flac   (29.1 MB)
-  ✓ Californication/Otherside.flac          (27.6 MB)
-  Scar Tissue            ━━━━━━━━━━━━━━━━╸━━━━━   68%  ·  3.9 MB/s
-  Get on Top             ━━━━━━━╸━━━━━━━━━━━━━━   31%  ·  4.2 MB/s
-  Around the World       ━━━━━━━━━━━━━━━━━━━━━━  100%
-  Done — OK:15  skipped:0  failed:0
-  → Files in ~/Downloads/music · log: …/run.log
-```
-
-## How it works (Cloudflare)
-
-lucida.to is behind Cloudflare and plain HTTP gets a `403`. lucidadl solves the
-challenge **once** in a real browser (`setup`), caches the `cf_clearance` cookie, then
-runs **everything else over `httpx`** — no browser stays open. The browser is only
-re-opened briefly if the cookie expires. Solving the challenge needs a logged-in
-desktop session (it can't run on a locked/headless server).
-
-## Requirements
-
-- Python **3.10+**
-- A desktop session for the one-time Cloudflare `setup` (Windows/macOS/Linux).
+- Track and album downloads from a search (`Artist - Title`) or a direct URL.
+- Parallel HTTP downloads with no browser left running in the background.
+- Qobuz search by default, with an automatic Amazon fallback.
+- FLAC source downloads and optional local MP3, AAC, Opus, Ogg, WAV, or FLAC conversion.
+- Tag-based organization under `Artists/<Artist>/<Album>/`.
+- Batch downloads from any `.txt` file, without modifying the source list.
+- Public Apple Music playlist import with ordered tracks and a portable `.m3u8` file.
+- Existence-aware deduplication, safe matching, and one-command retry for failures.
+- Guided first-run setup, diagnostics, progress bars, and a compact interactive menu.
 
 ## Install
 
-`lucidadl` is on [PyPI](https://pypi.org/project/lucidadl/); installing it adds a global
-**`lucida`** command (alias: `lucidadl`).
-
-> **Already using [lucida-downloader](https://github.com/jelni/lucida-downloader)?** Its
-> binary is also called `lucida`, so the two clash on your `PATH`. Just use the
-> **`lucidadl`** alias for this tool (e.g. `lucidadl track "…"`, `lucidadl ui`) — every
-> command below works the same with `lucidadl` in place of `lucida`.
-
-**Recommended — isolated, on PATH ([pipx](https://pipx.pypa.io)):**
+Python 3.10 or newer and a normal desktop session are required. Using
+[pipx](https://pipx.pypa.io) keeps the application isolated and available everywhere:
 
 ```bash
-pip install --user pipx && python -m pipx ensurepath   # once, if you don't have pipx
 pipx install lucidadl
-pipx run playwright install chromium                    # one-time: download the browser
+lucida setup
+lucida
 ```
 
-**Or with plain pip** (into your Python; its `Scripts`/`bin` must be on PATH):
+`lucida setup` installs the matching Playwright Chromium build when needed, opens
+lucida.to once for the Cloudflare check, then saves the resulting access locally.
+
+Plain pip also works:
 
 ```bash
 pip install lucidadl
-playwright install chromium
+lucida setup
 ```
 
-**From source** (for development — see [CONTRIBUTING.md](CONTRIBUTING.md)):
+Installing the package creates both `lucida` and `lucidadl`. If another application
+already owns the `lucida` command, use the `lucidadl` alias for every example below.
+
+## Three ways to download
+
+### 1. A track or album
+
+```bash
+lucida track "Daft Punk - Around the World"
+lucida album "Daft Punk - Discovery"
+```
+
+A direct Qobuz or Amazon URL can be used in place of the search text. Albums are
+expanded and downloaded track by track so the available parallelism is preserved.
+
+Use interactive search when you want to choose the result yourself:
+
+```bash
+lucida search "Discovery Daft Punk"
+```
+
+### 2. Many tracks or albums from a text file
+
+```bash
+lucida tracks --file "D:/music-lists/tracks.txt"
+lucida albums --file "D:/music-lists/albums.txt"
+```
+
+The format is deliberately simple: one search or direct URL per line. Blank lines and
+comments beginning with `#` are ignored.
+
+```text
+# Road-trip additions
+Daft Punk - Around the World
+The Chemical Brothers - Galvanize
+https://play.qobuz.com/track/24107150
+```
+
+The source file is never edited. Already downloaded items are skipped unless `--force`
+is used. When `--file` is omitted, the plural commands use `./inputs/tracks.txt` or
+`./inputs/albums.txt`; ready-to-copy examples are included in the repository.
+
+### 3. A public Apple Music playlist
+
+```bash
+lucida playlist "https://music.apple.com/.../pl.xxxxxxxx"
+```
+
+lucidadl reads the public Apple Music page, resolves each track through lucida.to, and
+stores the result under `Playlists/<playlist name>/`. An `.m3u8` file is written beside
+the tracks so players and devices recognize the folder as an actual playlist.
+
+Preview the extraction without downloading anything:
+
+```bash
+lucida playlist "https://music.apple.com/.../pl.xxxxxxxx" --dry-run
+```
+
+Apple Music is currently the only supported playlist source.
+
+## Interactive menu
+
+Run `lucida` without arguments (or `lucida ui`):
+
+```text
+╭────────────────── lucidadl ──────────────────╮
+│ 3 concurrent downloads · qobuz · original    │
+│ Music: ~/Downloads/music                     │
+│ Access: prepared                             │
+╰──────────────────────────────────────────────╯
+
+► What do you want to do?
+  ⬇   Download music
+  🎶  Import an Apple Music playlist
+  📄  Download from a .txt file
+  ⚙   Settings
+  🧰  Help, access and diagnostics
+  🚪  Quit
+```
+
+The menu remembers its download count, source service, conversion settings, and music
+folder. Each run ends with a readable summary and offers failed items for retry from the
+main menu.
+
+## Output and formats
+
+Music is saved to `~/Downloads/music` by default, independently of the directory from
+which lucidadl is launched:
+
+```text
+music/
+├── Artists/
+│   └── Artist/
+│       └── Album/
+└── Playlists/
+    └── Playlist name/
+        ├── 01 - Track.flac
+        └── Playlist name.m3u8
+```
+
+Change the main folder permanently or for one run:
+
+```bash
+lucida config --music "D:/Music"
+lucida track "Artist - Title" --out "E:/Temporary music"
+```
+
+For local conversion, lucidadl downloads the best source first and invokes the bundled
+ffmpeg executable:
+
+```bash
+lucida album "Artist - Album" --to mp3 --bitrate 320k --jobs 8
+```
+
+If conversion fails, the source audio is kept and the item is reported as failed rather
+than silently counted as a success.
+
+Useful download options:
+
+| Option | Purpose |
+|---|---|
+| `-j, --jobs N` | Parallel downloads, from 1 to 100 (default: 3) |
+| `-s, --service` | Primary search service: `qobuz` or `amazon` |
+| `--to FORMAT` | Local conversion to MP3, AAC/M4A, Opus, Ogg, FLAC, or WAV |
+| `--bitrate RATE` | Conversion bitrate such as `320k` or `192k` |
+| `--keep-original` | Keep the source FLAC after conversion |
+| `--flat` | Place files under `Music/` instead of organizing from tags |
+| `--force` | Ignore download history and fetch the item again |
+| `--hidden` | Move a necessary Cloudflare browser window off-screen |
+
+Run `lucida <command> --help` for the complete options of a command.
+
+## Access, failures, and diagnostics
+
+Cloudflare access is prepared once in a real Chromium window. Downloads then use a
+lightweight HTTP client. If the saved access expires, lucidadl briefly opens the browser
+again and refreshes it.
+
+```bash
+lucida doctor          # quick local check; never opens a browser
+lucida doctor --live   # browser and lucida.to connectivity check
+lucida setup           # install/repair Chromium and refresh access
+lucida retry           # retry only unresolved items from the previous run
+```
+
+Failed tracks and albums retain their original type. Automated and scheduled commands
+return a non-zero status while work remains unresolved. The latest details are stored in
+`run.log`; `lucida config` prints its exact location along with all other application
+paths.
+
+Common fixes:
+
+- No confident automatic match: use `lucida search` and choose the result manually.
+- Cloudflare or browser failure: run `lucida setup`, then `lucida doctor --live`.
+- Unexpected output folder: run `lucida config` and check `LUCIDADL_MUSIC`.
+- Another program uses the `lucida` command: call this application with `lucidadl`.
+
+## Scheduling a batch
+
+Once access has been prepared, a `.txt` batch can run unattended while its cached access
+remains valid. A Windows Scheduled Task helper is included:
+
+```powershell
+.\schedule.ps1 -Mode tracks -Time 21:30 -WorkingDir "D:\music-lists"
+```
+
+The scheduled task uses `inputs/tracks.txt` or `inputs/albums.txt` under its working
+directory. A logged-in desktop session is still required if Cloudflare access must be
+renewed.
+
+## Application data
+
+The browser profile, access data, configuration, deduplication state, last log, and
+failed-item list are stored outside the repository:
+
+- Windows: `%LOCALAPPDATA%\lucidadl`
+- Linux: `~/.local/share/lucidadl`
+- macOS: `~/Library/Application Support/lucidadl`
+
+Advanced overrides are available through `LUCIDADL_HOME` and `LUCIDADL_MUSIC`.
+
+## Development
 
 ```bash
 git clone https://github.com/Jude-A/lucidadl
 cd lucidadl
+python -m venv .venv
 pip install -e ".[dev]"
-playwright install chromium
+python selftest.py
 ```
 
-Open a new terminal afterwards so `lucida` is picked up. ffmpeg is bundled
-(`imageio-ffmpeg`) — nothing to install.
-
-## Quick start
-
-```bash
-lucida setup                                  # once: pass Cloudflare, cache the cookie
-lucida                                         # interactive menu (same as `lucida ui`)
-lucida track "Red Hot Chili Peppers - Otherside"
-lucida album "Red Hot Chili Peppers - Californication" --to mp3 --bitrate 320k -j 8
-```
-
-Prefer a menu? Run `lucida` with no arguments (or `lucida ui`): pick an action, type a
-query/URL, and watch one progress bar per parallel download. Your menu defaults
-(jobs, service, format, folder) are remembered.
-
-Files land in **one fixed folder** — `~/Downloads/music` by default (not the current
-directory, so they never scatter). Change it once with `lucida config --music "D:/Music"`
-(or the `LUCIDADL_MUSIC` env var), or per run with `-o`.
-
-## Commands
-
-Singular = ad-hoc (arguments, always downloads). Plural = watchlist (reads a file,
-skips already-downloaded items — for unattended/scheduled runs).
-
-| Command | Input | Dedup |
-|---------|-------|-------|
-| `lucida` / `lucida ui` | interactive menu | — |
-| `lucida track "<query\|url>"` | argument(s) | no (force) |
-| `lucida album "<query\|url>"` | argument(s) | no (force) |
-| `lucida tracks` | `./inputs/tracks.txt` | yes |
-| `lucida albums` | `./inputs/albums.txt` | yes |
-| `lucida playlist "<apple music url>"` | public playlist | yes |
-| `lucida search "<query>"` | interactive pick | no |
-| `lucida retry` | failed list | yes |
-| `lucida config` | show/set the music folder | — |
-| `lucida setup` | — | — |
-| `lucida doctor` | environment check | — |
-
-A search takes the best-matching result (title + artist, avoiding remix/cover/karaoke/
-live/… unless you ask for them). A playlist/album URL downloads all its tracks.
-
-## Options (download commands)
-
-- `-j, --jobs N` — parallel downloads, 1–100 (default 3).
-- `-s, --service` — `qobuz` (default) or `amazon`. If the primary finds nothing, it
-  falls back to the other automatically.
-- `-F, --format` — format requested from lucida (server-side, no bitrate control):
-  `original` (default) · `flac` · `mp3` · `ogg-vorbis` · `opus` · `m4a-aac` · `wav`.
-- `--to` — **local ffmpeg transcode** (recommended for a precise format/bitrate):
-  `mp3` · `aac`/`m4a` · `opus` · `ogg` · `flac` · `wav`. Downloads FLAC then converts.
-- `--bitrate` — e.g. `320k`, `256k`, `192k` (for `--to`).
-- `--keep-original` — keep the source FLAC next to the transcoded file.
-- `--force` — ignore the dedup memory and re-download even items already recorded as
-  done (handy if `state.json` drifted out of sync).
-- `--organize / --flat` — tag-based `Artists/<Artist>/<Album>/` (default) vs everything
-  flat in `<music folder>/Music/`.
-- `--country` — country code (default `US` for Qobuz; Amazon needs none).
-- `-o, --out` — output directory for this run (default: the configured music folder,
-  `~/Downloads/music`).
-- `--hidden / --visible` — if a Cloudflare refresh is needed, open the window
-  off-screen (`--hidden`) instead of visible.
-
-## Watchlists
-
-Copy the example files and edit them — one item per line (a search `artist - title`,
-or a direct URL):
-
-```bash
-cp inputs/tracks.txt.example inputs/tracks.txt
-cp inputs/albums.txt.example inputs/albums.txt
-```
-
-then:
-
-```bash
-lucida tracks      # downloads everything new, skips what's already done
-lucida albums
-```
-
-## Playlists
-
-```bash
-lucida playlist "https://music.apple.com/.../pl.xxxxxxxx" [--dry-run] [-j N]
-```
-
-Give it a playlist link: lucidadl reads the track list (title + artist) straight from the
-page, then downloads each track through lucida (Qobuz) into `Playlists/<playlist name>/`.
-`--dry-run` just lists them (and writes `./inputs/playlist.txt`) without downloading.
-
-**Only Apple Music is implemented today — that's what I use.** Adding other sources
-(Spotify, Deezer, Tidal…) is straightforward, and contributions are welcome. The playlist
-scraping all lives in [`lucidadl/api.py`](lucidadl/api.py):
-
-- `playlist_tracklist()` — picks a scraper based on the link's host.
-- `applemusic_tracklist()` — the working Apple Music scraper (your reference example).
-- `_scrape_playlist()` + `_PLAYLIST_SOURCES` — a generic scraper with per-site CSS
-  selectors (best-guess starting points for Spotify/Deezer/Tidal), gated behind the
-  `_PLAYLIST_OTHERS_ENABLED` flag.
-
-To add a source: flip `_PLAYLIST_OTHERS_ENABLED = True`, fix the selectors for your
-service in `_PLAYLIST_SOURCES`, test, and open a PR.
-
-## Scheduling / "in the background"
-
-The cookie is cached, so unattended runs open no browser (until it expires). Schedule a
-watchlist with your OS scheduler. A Windows example is provided in `schedule.ps1`.
-
-## Where files live
-
-- **Music**: one fixed folder, `~/Downloads/music` by default. Set it with
-  `lucida config --music "<path>"` or the `LUCIDADL_MUSIC` env var; `lucida config`
-  (no args) prints every path. Everything is saved here and deduped against here only.
-- **App data** (browser profile, `clearance.json`, dedup `state.json`, `config.json`,
-  `run.log`, `failed.txt`): the OS user data dir (`%LOCALAPPDATA%\lucidadl` on Windows,
-  `~/.local/share/lucidadl` on Linux, `~/Library/Application Support/lucidadl` on
-  macOS). Override with `LUCIDADL_HOME`.
-- **Watchlist inputs** (`tracks.txt`, `albums.txt`): `./inputs/` next to where you run
-  the command, so you can keep them in your project. Override per command with `-f`.
-
-## Troubleshooting
-
-- **Everything lands in `Unknown Artist/Unknown Album`** → `mutagen` is missing in the
-  Python that runs `lucida` (tags can't be read). `pip install mutagen` into that
-  interpreter (it's a declared dependency, so a normal `pip install .`/`pipx` install
-  pulls it). lucidadl now prints a warning when it's absent.
-- **"Cloudflare not cleared"** → run `lucida setup` again (the cached cookie expired).
-- **"Executable doesn't exist"** → run `playwright install chromium`.
-- **Search finds nothing** → try a direct URL, or `-s amazon`.
-- **`lucida doctor`** → checks Python, Playwright, and reachability.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for platform-specific setup and validation.
+Release changes are recorded in [CHANGELOG.md](CHANGELOG.md).
 
 ## Credits
 
-lucidadl takes inspiration from two existing open-source lucida.to downloaders we looked
-at while building it:
-
-- **[lucida-flow](https://github.com/ryanlong1004/lucida-flow)** — a Python CLI/API that
-  drives lucida.to through browser automation; the starting point for the browser side.
-- **[lucida-downloader](https://github.com/jelni/lucida-downloader)** — a fast,
-  multithreaded Rust client; the inspiration for downloading many tracks concurrently.
-
-It's a "vibe-coded" project (built quickly, AI-assisted), so expect rough edges — issues
-and PRs that sharpen or extend it are very welcome.
-
-## Contributing
-
-Bug reports and PRs welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for the dev setup
-and how to run the offline self-tests. Notable changes are tracked in
-[CHANGELOG.md](CHANGELOG.md).
+lucidadl takes inspiration from
+[lucida-flow](https://github.com/ryanlong1004/lucida-flow) and
+[lucida-downloader](https://github.com/jelni/lucida-downloader). The project started as
+a small, AI-assisted personal tool and remains intentionally focused on that scale.
 
 ## License
 
-MIT — see [LICENSE](LICENSE).
+[MIT](LICENSE)

--- a/inputs/albums.txt.example
+++ b/inputs/albums.txt.example
@@ -1,4 +1,4 @@
-# Watchlist of ALBUMS — one per line. Copy this file to `inputs/albums.txt` and edit.
+# Batch of ALBUMS — one per line. Copy this file to `inputs/albums.txt` and edit.
 # Run:  lucidadl albums
 #
 # Each line can be:

--- a/inputs/tracks.txt.example
+++ b/inputs/tracks.txt.example
@@ -1,4 +1,4 @@
-# Watchlist of TRACKS — one per line. Copy this file to `inputs/tracks.txt` and edit.
+# Batch of TRACKS — one per line. Copy this file to `inputs/tracks.txt` and edit.
 # Run:  lucidadl tracks
 #
 # Each line can be:

--- a/lucidadl/__init__.py
+++ b/lucidadl/__init__.py
@@ -1,3 +1,3 @@
 """lucidadl — automated music downloader driving lucida.to through a real browser."""
 
-__version__ = "0.1.0"
+__version__ = "1.1.0"

--- a/lucidadl/api.py
+++ b/lucidadl/api.py
@@ -21,7 +21,7 @@ import re
 import time
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 
-from . import utils
+from . import paths, utils
 
 LUCIDA = "https://lucida.to"
 STREAM_ACTION = "/api/fetch/stream/v2"
@@ -428,7 +428,7 @@ async def _playlist_name(page) -> str:
             continue
     try:
         t = (await page.title()).strip()
-        for suf in (" on Apple Music", " - playlist by ", " | Spotify", " | Deezer"):
+        for suf in (" on Apple Music", " - playlist by "):
             i = t.find(suf)
             if i > 0:
                 t = t[:i]
@@ -450,133 +450,26 @@ async def _dismiss_consent(page) -> None:
             continue
 
 
-# --- generic playlist scraping (Spotify / Deezer / Tidal) -------------------
-# Per-source row/title/artist CSS selectors. Best-guess; the failure dump lets us fix
-# them per service if a site's markup differs.
-_PLAYLIST_SOURCES = {
-    "open.spotify.com": {"row": '[data-testid="tracklist-row"]',
-                         "title": '[data-testid="internal-track-link"], a[href*="/track/"]',
-                         "artist": 'a[href*="/artist/"]'},
-    "deezer.com": {"row": '[role="row"]',
-                   "title": 'a[href*="/track/"], [data-testid="title"]',
-                   "artist": 'a[href*="/artist/"]'},
-    "tidal.com": {"row": '[data-test="tracklist-row"]',
-                  "title": '[data-test="table-row-title"], a[href*="/track/"]',
-                  "artist": '[data-test*="artist"] a, a[href*="/artist/"]'},
-    "listen.tidal.com": {"row": '[data-test="tracklist-row"]',
-                         "title": '[data-test="table-row-title"], a[href*="/track/"]',
-                         "artist": '[data-test*="artist"] a, a[href*="/artist/"]'},
-}
-
-_ROWS_JS = """([rowSel, titleSel, artistSel]) =>
-  Array.from(document.querySelectorAll(rowSel)).map(r => {
-    const t = r.querySelector(titleSel);
-    const arts = Array.from(r.querySelectorAll(artistSel))
-      .map(a => (a.textContent || '').trim()).filter(Boolean);
-    return { title: t ? (t.textContent || '').trim() : '', artist: arts.join(', ') };
-  })"""
-
-_SCROLL_GENERIC_JS = """(rowSel) => {
-  let el = document.querySelector(rowSel);
-  while (el) {
-    const s = getComputedStyle(el);
-    if (/(auto|scroll)/.test(s.overflowY) && el.scrollHeight > el.clientHeight + 10) break;
-    el = el.parentElement;
-  }
-  const t = el || document.scrollingElement || document.documentElement;
-  const step = Math.max(200, Math.round((t.clientHeight || window.innerHeight) * 0.7));
-  t.scrollTop += step;
-  return { top: t.scrollTop, h: t.scrollHeight, c: t.clientHeight };
-}"""
-
-
-def _playlist_source(url: str):
-    from urllib.parse import urlparse
-    host = (urlparse(url).hostname or "").lower()
-    for h, sel in _PLAYLIST_SOURCES.items():
-        if host == h or host.endswith("." + h) or h in host:
-            return h, sel
-    return None, None
-
-
-# Spotify/Deezer/Tidal scrapers exist (below) but their selectors are unvalidated;
-# disabled for now — flip to True to re-enable them.
-_PLAYLIST_OTHERS_ENABLED = False
-
-
 async def playlist_tracklist(page, url: str, log=print):
-    """Scrape a public playlist -> (name, [{title, artist}]). Only Apple Music is
-    active for now; Spotify/Deezer/Tidal are coded but disabled (_PLAYLIST_OTHERS_ENABLED)."""
+    """Scrape a public Apple Music playlist -> (name, [{title, artist}])."""
     from urllib.parse import urlparse
     host = (urlparse(url).hostname or "").lower()
-    if "music.apple.com" in host:
-        return await applemusic_tracklist(page, url, log)
-    if not _PLAYLIST_OTHERS_ENABLED:
-        log("  source not supported for now — only Apple Music is active "
-            "(Spotify/Deezer/Tidal coming soon).")
+    if host != "music.apple.com" and not host.endswith(".music.apple.com"):
+        log("  unsupported playlist URL — paste a public music.apple.com playlist link")
         return "", []
-    src, sel = _playlist_source(url)
-    if not sel:
-        log(f"  unrecognized playlist source: {host or url}")
-        return "", []
-    return await _scrape_playlist(page, url, sel, src, log)
-
-
-async def _scrape_playlist(page, url, sel, label, log):
-    try:
-        await page.goto(url, wait_until="domcontentloaded", timeout=60_000)
-    except Exception as e:
-        log(f"  {label} navigation: {e}")
-    await page.wait_for_timeout(1500)
-    await _dismiss_consent(page)
-    try:
-        await page.wait_for_selector(sel["row"], timeout=30_000)
-    except Exception:
-        pass
-
-    name = await _playlist_name(page)
-    tracks: List[Dict[str, str]] = []
-    seen = set()
-    stable = 0
-    args = [sel["row"], sel["title"], sel["artist"]]
-    for _ in range(800):
-        try:
-            rows = await page.evaluate(_ROWS_JS, args)
-        except Exception:
-            rows = []
-        new = 0
-        for t in rows:
-            title = (t.get("title") or "").strip()
-            artist = (t.get("artist") or "").strip()
-            if not title:
-                continue
-            key = (artist.lower(), title.lower())
-            if key not in seen:
-                seen.add(key)
-                tracks.append({"title": title, "artist": artist})
-                new += 1
-        if new:
-            log(f"    … {len(tracks)} titles")
-        try:
-            pos = await page.evaluate(_SCROLL_GENERIC_JS, sel["row"])
-        except Exception:
-            pos = None
-        await page.wait_for_timeout(300)
-        at_bottom = bool(pos) and (pos["top"] + pos["c"] >= pos["h"] - 8)
-        stable = stable + 1 if new == 0 else 0
-        if (at_bottom and stable >= 3) or stable >= 30:
-            break
+    name, tracks = await applemusic_tracklist(page, url, log)
     if not tracks:
-        await _dump_playlist_debug(page, label)
+        await _dump_playlist_debug(page)
     return name, tracks
 
 
-async def _dump_playlist_debug(page, label) -> None:
+async def _dump_playlist_debug(page) -> None:
+    """Best-effort capture for support, kept with other app data (never in the cwd)."""
     try:
-        out = os.path.join(os.getcwd(), f"{label}_debug.html")
+        out = os.path.join(paths.DATA_DIR, "applemusic_debug.html")
         with open(out, "w", encoding="utf-8") as f:
             f.write(await page.content())
-        await page.screenshot(path=os.path.join(os.getcwd(), f"{label}_debug.png"))
+        await page.screenshot(path=os.path.join(paths.DATA_DIR, "applemusic_debug.png"))
     except Exception:
         pass
 

--- a/lucidadl/cli.py
+++ b/lucidadl/cli.py
@@ -6,7 +6,7 @@ import asyncio
 import os
 import sys
 import traceback
-from typing import List, Optional
+from typing import Dict, List, Optional, Tuple
 
 import click
 
@@ -14,11 +14,12 @@ from . import api, organize, paths, progress, transcode, utils
 from .api import LucidaClient, default_country, normalize_service, DOWNSCALE_CHOICES, LUCIDA
 from .downloader import run_batch
 from .session import (lucida_context, ensure_cleared, get_page, BrowserClosed,
-                      acquire_clearance, load_clearance)
+                      acquire_clearance, load_clearance, chromium_installed,
+                      install_chromium)
 
 # App data (cookie/profile/state/log/failed list) lives in the fixed user data dir.
-# Downloads go to ONE fixed, configurable music directory (never the cwd). Only the
-# watchlist inputs stay next to you, so you can edit them where you work.
+# Downloads go to ONE fixed, configurable music directory (never the cwd). Default
+# batch input files stay next to you, and any text file can be selected with --file.
 STATE_PATH = paths.STATE_PATH
 DEFAULT_OUT = paths.default_music_dir()
 INPUTS = paths.cwd("inputs")
@@ -26,17 +27,28 @@ LOG_PATH = paths.LOG_PATH
 FAILED_PATH = paths.FAILED_PATH
 
 
-def _write_failed(items) -> None:
+FailedItem = Tuple[str, str]
+RunResult = Tuple[Dict[str, int], List[FailedItem]]
+
+
+def _write_failed(items: List[FailedItem]) -> None:
     try:
+        if not items:
+            try:
+                os.remove(FAILED_PATH)
+            except FileNotFoundError:
+                pass
+            return
         with open(FAILED_PATH, "w", encoding="utf-8") as f:
             f.write("# Failed items — re-run with: lucidadl retry\n")
-            f.write("\n".join(items) + "\n")
+            f.write("# kind<TAB>query or URL\n")
+            f.writelines(f"{kind}\t{item}\n" for kind, item in items)
     except Exception as e:
         # don't fail silently: the user is told to `retry`, but the list wasn't saved.
         click.secho(f"⚠ couldn't write {FAILED_PATH} ({e}) — `retry` won't have these "
                     f"items. Re-run them manually:", fg="yellow")
-        for it in items:
-            click.echo(f"    {it}")
+        for kind, item in items:
+            click.echo(f"    {kind}: {item}")
 
 _CLOSED_HINT = (
     "The browser closed on its own. Try: (1) re-run; (2) close any open Chrome "
@@ -54,6 +66,39 @@ def _read_lines(path: str) -> List[str]:
             if line and not line.startswith("#"):
                 out.append(line)
     return out
+
+
+def _read_failed() -> List[FailedItem]:
+    """Read typed failures; old untyped failed.txt entries remain track retries."""
+    out: List[FailedItem] = []
+    for line in _read_lines(FAILED_PATH):
+        kind, sep, item = line.partition("\t")
+        if sep and kind in ("track", "album") and item:
+            out.append((kind, item))
+        else:
+            out.append(("track", line))
+    return out
+
+
+def _read_batch(path: str, label: str) -> List[str]:
+    """Read a batch input while distinguishing a missing file from an empty one."""
+    if not os.path.isfile(path):
+        click.secho(f"Batch file not found: {os.path.abspath(path)}", fg="red")
+        click.echo(f"Choose one with: lucida {label} --file \"path/to/{label}.txt\"")
+        raise click.exceptions.Exit(1)
+    items = _read_lines(path)
+    if not items:
+        click.secho(f"Batch file is empty: {os.path.abspath(path)}", fg="yellow")
+    return items
+
+
+def _failed_result(items: List[str], kind: str) -> RunResult:
+    return ({"ok": 0, "skip": 0, "fail": len(items)}, [(kind, item) for item in items])
+
+
+def _exit_if_failed(result: RunResult) -> None:
+    if result[0]["fail"] or result[1]:
+        raise click.exceptions.Exit(1)
 
 
 def _service_opts(f):
@@ -112,10 +157,10 @@ async def _run(items: List[str], kind: str, service: str, country: Optional[str]
                organize_on: bool = True, to_fmt: Optional[str] = None,
                bitrate: Optional[str] = None, keep_orig: bool = False,
                collection: Optional[str] = None, force: bool = False,
-               quiet_resolve: bool = False) -> None:
+               quiet_resolve: bool = False, save_failures: bool = True) -> RunResult:
     if not items:
         click.secho("Nothing to download.", fg="yellow")
-        return
+        return {"ok": 0, "skip": 0, "fail": 0}, []
     if force:
         dedup = False  # re-download even what state.json remembers
     cc = country or default_country(service)
@@ -127,7 +172,10 @@ async def _run(items: List[str], kind: str, service: str, country: Optional[str]
         if not transcode.available():
             click.secho("⚠ ffmpeg not found — install it (pip install imageio-ffmpeg) "
                         "or drop --to.", fg="red")
-            return
+            result = _failed_result(items, kind)
+            if save_failures:
+                _write_failed(result[1])
+            return result
     if organize_on and not organize.mutagen_available():
         click.secho("⚠ mutagen not found — tags can't be read; sorting by "
                     "artist/album will rely on the API metadata (otherwise "
@@ -137,6 +185,7 @@ async def _run(items: List[str], kind: str, service: str, country: Optional[str]
     logf = open(LOG_PATH, "w", encoding="utf-8")
     reporter = progress.make_reporter(echo=click.echo, logfile=logf)
     log = reporter.log
+    result = _failed_result(items, kind)
 
     log(f"# lucidadl — kind={kind} service={service} country={cc!r} "
         f"format={downscale} jobs={jobs} dedup={dedup} "
@@ -151,10 +200,14 @@ async def _run(items: List[str], kind: str, service: str, country: Optional[str]
                 cf, ua = await acquire_clearance(hidden=hidden)
             except BrowserClosed:
                 log(_CLOSED_HINT)
-                return
+                if save_failures:
+                    _write_failed(result[1])
+                return result
             except Exception as e:
                 log(f"Couldn't clear Cloudflare: {e}. Run `setup`.")
-                return
+                if save_failures:
+                    _write_failed(result[1])
+                return result
 
         async def _acquire():
             return await acquire_clearance(hidden=hidden)
@@ -171,13 +224,17 @@ async def _run(items: List[str], kind: str, service: str, country: Optional[str]
         finally:
             await client.aclose()
         log(f"\nDone — OK:{totals['ok']}  skipped:{totals['skip']}  failed:{totals['fail']}")
-        if failed:
+        result = totals, failed
+        if save_failures:
             _write_failed(failed)
+        if failed and save_failures:
             log(f"  → {len(failed)} failure(s) written to {FAILED_PATH} "
                 f"(re-run: lucida retry)")
     except Exception as e:
         log(f"FATAL ERROR: {e}")
         log(traceback.format_exc())
+        if save_failures:
+            _write_failed(result[1])
     finally:
         try:
             reporter.close()
@@ -188,6 +245,7 @@ async def _run(items: List[str], kind: str, service: str, country: Optional[str]
         except Exception:
             pass
     click.secho(f"→ Files in {out}  ·  log: {LOG_PATH}", fg="cyan")
+    return result
 
 
 # --- ad-hoc (singular): args, no dedup -------------------------------------
@@ -198,9 +256,11 @@ async def _run(items: List[str], kind: str, service: str, country: Optional[str]
 def track_cmd(items, service, country, downscale, out, organize_on, jobs, to_fmt,
               bitrate, keep_orig, force, hidden):
     """One or more tracks now: track "artist - title" (or URL). Forces the DL."""
-    asyncio.run(_run(list(items), "track", service, country, downscale, out,
-                     hidden, jobs, dedup=False, organize_on=organize_on,
-                     to_fmt=to_fmt, bitrate=bitrate, keep_orig=keep_orig, force=force))
+    result = asyncio.run(_run(list(items), "track", service, country, downscale, out,
+                              hidden, jobs, dedup=False, organize_on=organize_on,
+                              to_fmt=to_fmt, bitrate=bitrate, keep_orig=keep_orig,
+                              force=force))
+    _exit_if_failed(result)
 
 
 @cli.command("album")
@@ -209,12 +269,14 @@ def track_cmd(items, service, country, downscale, out, organize_on, jobs, to_fmt
 def album_cmd(items, service, country, downscale, out, organize_on, jobs,
               to_fmt, bitrate, keep_orig, force, hidden):
     """One or more albums now: album "artist - album" (or URL), expanded track by track."""
-    asyncio.run(_run(list(items), "album", service, country, downscale, out,
-                     hidden, jobs, dedup=False, organize_on=organize_on,
-                     to_fmt=to_fmt, bitrate=bitrate, keep_orig=keep_orig, force=force))
+    result = asyncio.run(_run(list(items), "album", service, country, downscale, out,
+                              hidden, jobs, dedup=False, organize_on=organize_on,
+                              to_fmt=to_fmt, bitrate=bitrate, keep_orig=keep_orig,
+                              force=force))
+    _exit_if_failed(result)
 
 
-# --- watchlist (plural): file, with dedup ----------------------------------
+# --- batch files (plural commands): file input, with dedup ------------------
 
 @cli.command("tracks")
 @click.option("-f", "--file", "file", default=os.path.join(INPUTS, "tracks.txt"),
@@ -222,10 +284,13 @@ def album_cmd(items, service, country, downscale, out, organize_on, jobs,
 @_service_opts
 def tracks_cmd(file, service, country, downscale, out, organize_on, jobs, to_fmt,
                bitrate, keep_orig, force, hidden):
-    """Tracks watchlist: download inputs/tracks.txt (dedup enabled)."""
-    asyncio.run(_run(_read_lines(file), "track", service, country, downscale, out,
-                     hidden, jobs, dedup=True, organize_on=organize_on,
-                     to_fmt=to_fmt, bitrate=bitrate, keep_orig=keep_orig, force=force))
+    """Download tracks listed in a text file (dedup enabled)."""
+    result = asyncio.run(_run(_read_batch(file, "tracks"), "track", service, country,
+                              downscale, out,
+                              hidden, jobs, dedup=True, organize_on=organize_on,
+                              to_fmt=to_fmt, bitrate=bitrate, keep_orig=keep_orig,
+                              force=force))
+    _exit_if_failed(result)
 
 
 @cli.command("albums")
@@ -234,10 +299,13 @@ def tracks_cmd(file, service, country, downscale, out, organize_on, jobs, to_fmt
 @_service_opts
 def albums_cmd(file, service, country, downscale, out, organize_on, jobs,
                to_fmt, bitrate, keep_orig, force, hidden):
-    """Albums watchlist: download inputs/albums.txt (dedup enabled)."""
-    asyncio.run(_run(_read_lines(file), "album", service, country, downscale, out,
-                     hidden, jobs, dedup=True, organize_on=organize_on,
-                     to_fmt=to_fmt, bitrate=bitrate, keep_orig=keep_orig, force=force))
+    """Download albums listed in a text file (dedup enabled)."""
+    result = asyncio.run(_run(_read_batch(file, "albums"), "album", service, country,
+                              downscale, out,
+                              hidden, jobs, dedup=True, organize_on=organize_on,
+                              to_fmt=to_fmt, bitrate=bitrate, keep_orig=keep_orig,
+                              force=force))
+    _exit_if_failed(result)
 
 
 @cli.command("retry")
@@ -245,21 +313,48 @@ def albums_cmd(file, service, country, downscale, out, organize_on, jobs,
 def retry_cmd(service, country, downscale, out, organize_on, jobs, to_fmt,
               bitrate, keep_orig, force, hidden):
     """Re-run the failed items from the last run (failed.txt)."""
-    items = _read_lines(FAILED_PATH)
+    items = _read_failed()
     if not items:
         click.secho("No failures to re-run (failed.txt is empty).", fg="yellow")
         return
-    asyncio.run(_run(items, "track", service, country, downscale, out,
-                     hidden, jobs, dedup=True, organize_on=organize_on,
-                     to_fmt=to_fmt, bitrate=bitrate, keep_orig=keep_orig, force=force))
+    result = asyncio.run(_retry(items, service, country, downscale, out, hidden, jobs,
+                                organize_on, to_fmt, bitrate, keep_orig, force))
+    _exit_if_failed(result)
+
+
+async def _retry(items: List[FailedItem], service: str, country: Optional[str],
+                 downscale: str, out: str, hidden: bool, jobs: int,
+                 organize_on: bool = True, to_fmt: Optional[str] = None,
+                 bitrate: Optional[str] = None, keep_orig: bool = False,
+                 force: bool = False) -> RunResult:
+    """Retry failures by their original type, then keep only what still failed."""
+    totals = {"ok": 0, "skip": 0, "fail": 0}
+    remaining: List[FailedItem] = []
+    for kind in ("track", "album"):
+        values = [item for item_kind, item in items if item_kind == kind]
+        if not values:
+            continue
+        click.secho(f"\nRetrying {len(values)} {kind}{'s' if len(values) != 1 else ''}…",
+                    fg="cyan")
+        result = await _run(values, kind, service, country, downscale, out, hidden, jobs,
+                            dedup=True, organize_on=organize_on, to_fmt=to_fmt,
+                            bitrate=bitrate, keep_orig=keep_orig, force=force,
+                            save_failures=False)
+        for key in totals:
+            totals[key] += result[0][key]
+        remaining.extend(result[1])
+    _write_failed(remaining)
+    if not remaining:
+        click.secho("\n✓ All previous failures were resolved.", fg="green")
+    return totals, remaining
 
 
 # --- interactive search ----------------------------------------------------
 
-async def _search_entries(query, service, hidden=False):
+async def _search_entries(query, service, hidden=False, country=None):
     """Run a search and return a flat list of (kind, item) entries (albums then tracks).
     Shared by the CLI `search` prompt and the TUI's arrow-key picker."""
-    cc = default_country(service)
+    cc = country or default_country(service)
     cf, ua = load_clearance()
     if not (cf and ua):
         cf, ua = await acquire_clearance(hidden=hidden)
@@ -276,51 +371,52 @@ async def _search_entries(query, service, hidden=False):
 
 
 async def _search(query, service, country, downscale, out, organize_on, jobs,
-                  to_fmt, bitrate, keep_orig, hidden, force=False):
-    cc = country or default_country(service)
-    cf, ua = load_clearance()
-    if not (cf and ua):
-        try:
-            cf, ua = await acquire_clearance(hidden=hidden)
-        except Exception as e:
-            click.secho(f"Cloudflare: {e}. Run `setup`.", fg="red")
-            return
-    client = LucidaClient(cf, ua, acquire=lambda: acquire_clearance(hidden=hidden),
-                          country=cc, downscale=downscale, log=click.echo)
-    await client.start_http()
+                  to_fmt, bitrate, keep_orig, hidden,
+                  force=False) -> Optional[RunResult]:
     try:
-        res = await client.search(query, service)
-    finally:
-        await client.aclose()
+        entries = await _search_entries(query, service, hidden=hidden, country=country)
+    except BrowserClosed:
+        click.secho(_CLOSED_HINT, fg="red")
+        return {"ok": 0, "skip": 0, "fail": 1}, []
+    except Exception as e:
+        click.secho(f"Search failed: {e}. Try `lucida setup` or `lucida doctor --live`.",
+                    fg="red")
+        return {"ok": 0, "skip": 0, "fail": 1}, []
 
-    entries = []
-    albums, tracks = res.get("albums") or [], res.get("tracks") or []
+    albums = [it for kind, it in entries if kind == "album"]
+    tracks = [it for kind, it in entries if kind == "track"]
+    numbered = []
     if albums:
         click.secho("\nAlbums:", fg="cyan")
-        for it in albums[:15]:
-            entries.append(("album", it))
-            click.echo(f"  {len(entries):>2}. {it.get('title', '?')} — {it.get('artist', '?')}")
+        for it in albums:
+            numbered.append(("album", it))
+            click.echo(f"  {len(numbered):>2}. {it.get('title', '?')} — "
+                       f"{it.get('artist', '?')}")
     if tracks:
         click.secho("\nTracks:", fg="cyan")
-        for it in tracks[:15]:
-            entries.append(("track", it))
+        for it in tracks:
+            numbered.append(("track", it))
             alb = f"  [{it.get('album', '')}]" if it.get("album") else ""
-            click.echo(f"  {len(entries):>2}. {it.get('title', '?')} — {it.get('artist', '?')}{alb}")
-    if not entries:
+            click.echo(f"  {len(numbered):>2}. {it.get('title', '?')} — "
+                       f"{it.get('artist', '?')}{alb}")
+    if not numbered:
         click.secho("No results.", fg="yellow")
-        return
+        return {"ok": 0, "skip": 0, "fail": 1}, []
 
     try:
         sel = (await asyncio.to_thread(input, "\nNumber to download (Enter = cancel): ")).strip()
     except EOFError:
         sel = ""
-    if not sel.isdigit() or not (1 <= int(sel) <= len(entries)):
+    if not sel:
         click.echo("Cancelled.")
-        return
-    kind, item = entries[int(sel) - 1]
-    await _run([item["url"]], kind, service, country, downscale, out, hidden, jobs,
-               dedup=False, organize_on=organize_on, to_fmt=to_fmt, bitrate=bitrate,
-               keep_orig=keep_orig, force=force)
+        return None
+    if not sel.isdigit() or not (1 <= int(sel) <= len(numbered)):
+        click.secho("Invalid selection.", fg="red")
+        return {"ok": 0, "skip": 0, "fail": 1}, []
+    kind, item = numbered[int(sel) - 1]
+    return await _run([item["url"]], kind, service, country, downscale, out, hidden,
+                      jobs, dedup=False, organize_on=organize_on, to_fmt=to_fmt,
+                      bitrate=bitrate, keep_orig=keep_orig, force=force)
 
 
 @cli.command("search")
@@ -329,11 +425,14 @@ async def _search(query, service, country, downscale, out, organize_on, jobs,
 def search_cmd(query, service, country, downscale, out, organize_on, jobs,
                to_fmt, bitrate, keep_orig, force, hidden):
     """Interactive search: lists the results, downloads the one you pick."""
-    asyncio.run(_search(" ".join(query), service, country, downscale, out, organize_on,
-                        jobs, to_fmt, bitrate, keep_orig, hidden, force=force))
+    result = asyncio.run(_search(" ".join(query), service, country, downscale, out,
+                                 organize_on, jobs, to_fmt, bitrate, keep_orig, hidden,
+                                 force=force))
+    if result is not None:
+        _exit_if_failed(result)
 
 
-# --- playlist import (Apple Music / Spotify / Deezer / Tidal) --------------
+# --- Apple Music playlist import -------------------------------------------
 
 def _render_playlist(collection: str, tracks: list, dry_run: bool) -> None:
     """Compact, pretty playlist summary: a rich table for --dry-run, a single header
@@ -375,7 +474,14 @@ def _render_playlist(collection: str, tracks: list, dry_run: bool) -> None:
 
 async def _playlist(url, dry_run, service, country, downscale, out, hidden,
                     jobs, organize_on=True, to_fmt=None, bitrate=None, keep_orig=False,
-                    force=False):
+                    force=False) -> bool:
+    from urllib.parse import urlparse
+
+    host = (urlparse(url).hostname or "").lower()
+    if host != "music.apple.com" and not host.endswith(".music.apple.com"):
+        click.secho("Only public Apple Music playlist links are supported.", fg="red")
+        return False
+
     cc = country or default_country(service)
     name, tracks = "", []
 
@@ -401,14 +507,15 @@ async def _playlist(url, dry_run, service, country, downscale, out, hidden,
             name, tracks = await _scrape(headless=False)
     except BrowserClosed:
         click.secho(_CLOSED_HINT, fg="red")
-        return
+        return False
     except Exception as e:
         click.secho(f"✗ playlist extraction: {e}", fg="red")
-        return
+        return False
 
     if not tracks:
-        click.secho("No tracks extracted (a <source>_debug.html may have been written).", fg="red")
-        return
+        click.secho("No tracks extracted. Diagnostic files were saved in the app data "
+                    "folder; run `lucida config` to see its location.", fg="red")
+        return False
 
     collection = name or "Playlist"
     items = [f"{t['artist']} - {t['title']}" for t in tracks]
@@ -423,10 +530,12 @@ async def _playlist(url, dry_run, service, country, downscale, out, hidden,
     if dry_run:
         click.secho("--dry-run: nothing downloaded (list saved to inputs/playlist.txt).",
                     fg="yellow")
-        return
-    await _run(items, "track", service, country, downscale, out, hidden, jobs,
-               dedup=True, organize_on=organize_on, to_fmt=to_fmt, bitrate=bitrate,
-               keep_orig=keep_orig, collection=collection, force=force, quiet_resolve=True)
+        return True
+    result = await _run(items, "track", service, country, downscale, out, hidden, jobs,
+                        dedup=True, organize_on=organize_on, to_fmt=to_fmt,
+                        bitrate=bitrate, keep_orig=keep_orig, collection=collection,
+                        force=force, quiet_resolve=True)
+    return not (result[0]["fail"] or result[1])
 
 
 @cli.command("playlist")
@@ -435,11 +544,12 @@ async def _playlist(url, dry_run, service, country, downscale, out, hidden,
 @_service_opts
 def playlist_cmd(url, dry_run, service, country, downscale, out, organize_on, jobs,
                  to_fmt, bitrate, keep_orig, force, hidden):
-    """Import an Apple Music playlist (public link) → download each track via lucida.
-    (Spotify/Deezer/Tidal coded but disabled for now.)"""
-    asyncio.run(_playlist(url, dry_run, service, country, downscale, out, hidden,
-                          jobs, organize_on, to_fmt=to_fmt, bitrate=bitrate,
-                          keep_orig=keep_orig, force=force))
+    """Import a public Apple Music playlist and download its tracks via lucida."""
+    ok = asyncio.run(_playlist(url, dry_run, service, country, downscale, out, hidden,
+                               jobs, organize_on, to_fmt=to_fmt, bitrate=bitrate,
+                               keep_orig=keep_orig, force=force))
+    if not ok:
+        raise click.exceptions.Exit(1)
 
 
 # --- config -----------------------------------------------------------------
@@ -469,52 +579,91 @@ def config_cmd(music):
 
 # --- setup / doctor / debug -------------------------------------------------
 
-async def _setup():
-    click.echo("Opening the browser… (solve any captcha)")
+async def _setup() -> bool:
+    click.secho("\nlucidadl setup", bold=True)
+    click.echo("[1/2] Checking the browser…")
+    if not await chromium_installed():
+        click.echo("      Chromium is missing. Downloading it once for lucidadl…")
+        if not await install_chromium():
+            click.secho("✗ Chromium could not be installed.", fg="red")
+            click.echo(f"  Try manually: \"{sys.executable}\" -m playwright install chromium")
+            return False
+        click.secho("      ✓ Chromium installed", fg="green")
+    else:
+        click.secho("      ✓ Chromium is ready", fg="green")
+
+    click.echo("[2/2] Opening lucida.to…")
+    click.echo("      Complete the Cloudflare check in the browser if it appears.")
     try:
         await acquire_clearance(hidden=False)  # clears CF and SAVES the cookie to disk
     except BrowserClosed:
         click.secho(_CLOSED_HINT, fg="red")
-        return
+        return False
     except Exception as e:
         click.secho(f"⚠ {e} — try `setup` again.", fg="yellow")
-        return
-    click.secho("✓ Cloudflare passed, cookie saved (downloads won't open a browser "
-                "anymore as long as it's valid).", fg="green")
+        return False
+    click.secho("\n✓ Setup complete. You can now download music with `lucida`.", fg="green")
+    click.echo("  The browser will stay closed until Cloudflare asks for a new check.")
+    return True
 
 
 @cli.command()
 def setup():
-    """Open the browser once to pass Cloudflare and save the cookie."""
-    asyncio.run(_setup())
+    """Install the browser if needed, then prepare access to lucida.to."""
+    if not asyncio.run(_setup()):
+        raise click.exceptions.Exit(1)
 
 
-async def _doctor():
+async def _doctor(live: bool = False) -> bool:
+    browser_ok = await chromium_installed()
+    ffmpeg_ok = transcode.available()
+    cf, ua = load_clearance()
+    access_ok = bool(cf and ua)
+
+    click.secho("\nlucidadl doctor", bold=True)
     click.echo(f"Python      : {sys.version.split()[0]}")
-    try:
-        import playwright  # noqa
-        click.echo("Playwright  : installed")
-    except Exception as e:
-        click.secho(f"Playwright  : MISSING ({e})", fg="red")
-    click.echo(f"Data        : {paths.DATA_DIR}")
-    click.echo(f"Profile     : {paths.PROFILE_DIR}")
-    click.echo(f"Music       : {DEFAULT_OUT}")
-    click.echo(f"State/dedup : {STATE_PATH}")
-    click.echo(f"Log         : {LOG_PATH}")
-    click.echo("Testing browser + Cloudflare…")
-    try:
-        async with lucida_context(headless=False) as ctx:
-            ok = await ensure_cleared(ctx, timeout=120)
-            click.secho("✓ lucida.to reachable" if ok else "⚠ Cloudflare not cleared",
-                        fg="green" if ok else "yellow")
-    except Exception as e:
-        click.secho(f"✗ Browser launch failed: {e}", fg="red")
+    click.secho(f"Browser     : {'ready' if browser_ok else 'missing'}",
+                fg="green" if browser_ok else "yellow")
+    click.secho(f"ffmpeg      : {'ready' if ffmpeg_ok else 'missing'}",
+                fg="green" if ffmpeg_ok else "yellow")
+    click.secho(f"Access      : {'saved' if access_ok else 'not prepared'}",
+                fg="green" if access_ok else "yellow")
+    click.echo(f"Music       : {paths.default_music_dir()}")
+    click.echo(f"App data    : {paths.DATA_DIR}")
+
+    live_ok = True
+    if live:
+        if not browser_ok:
+            click.secho("\nLive check skipped: Chromium is missing.", fg="yellow")
+            live_ok = False
+        else:
+            click.echo("\nOpening the browser to test lucida.to…")
+            try:
+                async with lucida_context(headless=False) as ctx:
+                    live_ok = await ensure_cleared(ctx, timeout=120)
+                click.secho("✓ lucida.to is reachable" if live_ok
+                            else "⚠ Cloudflare was not cleared",
+                            fg="green" if live_ok else "yellow")
+            except Exception as e:
+                live_ok = False
+                click.secho(f"✗ Browser launch failed: {e}", fg="red")
+    else:
+        click.echo("Live check  : not run (use `lucida doctor --live`)")
+
+    if not browser_ok or not access_ok:
+        click.secho("\nNext step: run `lucida setup`.", fg="cyan")
+    elif not live:
+        click.secho("\nEverything needed is present.", fg="green")
+    return browser_ok and ffmpeg_ok and access_ok and live_ok
 
 
 @cli.command()
-def doctor():
-    """Diagnose the environment and lucida.to reachability."""
-    asyncio.run(_doctor())
+@click.option("--live", is_flag=True,
+              help="Open the browser and verify access to lucida.to.")
+def doctor(live):
+    """Check the installation. Add --live for a browser/network test."""
+    if not asyncio.run(_doctor(live=live)):
+        raise click.exceptions.Exit(1)
 
 
 async def _debug(query, service, country, item, headless):
@@ -562,7 +711,7 @@ async def _debug(query, service, country, item, headless):
             pass
 
 
-@cli.command("debug")
+@cli.command("debug", hidden=True)
 @click.argument("query", nargs=-1)
 @click.option("-s", "--service", default="qobuz", help="Service to diagnose (def: qobuz).")
 @click.option("--country", default=None, help="Country code (def: US for qobuz).")

--- a/lucidadl/downloader.py
+++ b/lucidadl/downloader.py
@@ -53,18 +53,23 @@ async def _resolve_url(client: LucidaClient, line: str, service: str, kind: str,
                 services.append(s)
     bucket = "albums" if kind == "album" else "tracks"
     variants = _query_variants(line)
+    explicit_artist = " - " in line
+    uncertain = False
     for i, svc in enumerate(services):
         for v_idx, q in enumerate(variants):
             res = await client.search(q, svc)
             items = res.get(bucket) or []
-            if not items and kind == "album":
-                items = res.get("tracks") or []
             if not items:
                 continue
             # The full query keeps its lenient match; broadened variants must match the
             # artist, so a title-only search can't silently grab the wrong artist.
-            url = matching.pick_best(line, items, require_artist=(v_idx > 0))
+            url = matching.pick_best(
+                line, items, require_artist=(v_idx > 0),
+                min_score=5.5 if explicit_artist else None,
+                min_margin=0.25 if explicit_artist else 0.0,
+            )
             if not url:
+                uncertain = uncertain or explicit_artist
                 continue
             if not quiet:  # playlists (many items) suppress this per-track confirmation
                 chosen = next((it for it in items if it.get("url") == url), {})
@@ -73,6 +78,9 @@ async def _resolve_url(client: LucidaClient, line: str, service: str, kind: str,
                 log(f"  ↳ chosen: \"{chosen.get('title', '?')}\" — "
                     f"{chosen.get('artist', '?')}{tag}{via} (among {len(items)} results)")
             return url
+    if uncertain and not quiet:
+        log(f"  ↳ no confident match for {line!r}; "
+            "use `lucida search` to choose manually")
     return None
 
 
@@ -172,7 +180,7 @@ async def _download_target(client, state, target, country, out, dedup, organize_
         reporter.finish(url, False, f"  ✗ {label}: {last_err}")
         async with lock:
             totals["fail"] += 1
-            failed.append(url)  # a track URL: `retry` can re-download it directly
+            failed.append(("track", url))  # retry can download this resolved track directly
         return
 
     finals = [path]
@@ -196,10 +204,11 @@ async def _download_target(client, state, target, country, out, dedup, organize_
             reporter.finish(url, False, f"  ✗ {label}: organized with no file (empty archive?)")
             async with lock:
                 totals["fail"] += 1
-                failed.append(url)
+                failed.append(("track", url))
             return
     if tx and tx.get("fmt"):
         converted = []
+        transcode_error = None
         for fp in finals:
             try:
                 converted.append(await asyncio.to_thread(
@@ -208,7 +217,20 @@ async def _download_target(client, state, target, country, out, dedup, organize_
             except Exception as e:
                 log(f"  ⚠ transcode failed ({os.path.basename(fp)}): {e}")
                 converted.append(fp)
+                transcode_error = e
         finals = converted
+        if transcode_error is not None:
+            if reserved:
+                state.release(url)
+            reporter.finish(
+                url, False,
+                f"  ✗ {label}: downloaded, but {tx['fmt']} conversion failed "
+                f"(original kept): {transcode_error}",
+            )
+            async with lock:
+                totals["fail"] += 1
+                failed.append(("track", url))
+            return
 
     async with lock:
         totals["ok"] += 1
@@ -227,12 +249,14 @@ async def run_batch(client: LucidaClient, state: utils.State, items: List[str],
                     tx: Optional[Dict] = None, strict: bool = False,
                     collection: Optional[str] = None, reporter=None,
                     quiet_resolve: bool = False
-                    ) -> Tuple[Dict[str, int], List[str]]:
+                    ) -> Tuple[Dict[str, int], List[Tuple[str, str]]]:
     if reporter is None:
         reporter = progress.TextReporter(print)
     log = reporter.log
     totals = {"ok": 0, "skip": 0, "fail": 0}
-    failed: List[str] = []
+    # (kind, query-or-URL): resolution failures keep their original kind; failures
+    # after an album was expanded are direct track URLs and can be retried as tracks.
+    failed: List[Tuple[str, str]] = []
     sem = asyncio.Semaphore(max(1, jobs))
     lock = asyncio.Lock()
 
@@ -249,13 +273,13 @@ async def run_batch(client: LucidaClient, state: utils.State, items: List[str],
                 log(f"  ✗ resolving \"{line}\": {e}")
                 async with lock:
                     totals["fail"] += 1
-                    failed.append(line)
+                    failed.append((kind, line))
                 return
             if tg is None:
-                log(f"  ⃠ not found, skipped: {line}")
+                log(f"  ✗ not found: {line}")
                 async with lock:
-                    totals["skip"] += 1
-                    failed.append(line)  # so `retry` can re-search it later
+                    totals["fail"] += 1
+                    failed.append((kind, line))  # so `retry` searches the right kind
                 return
             for t in tg:  # keep the source order (used to number playlist tracks)
                 t["track_no"] = f"{idx + 1:0{pad}d}"
@@ -279,7 +303,7 @@ async def run_batch(client: LucidaClient, state: utils.State, items: List[str],
                 log(f"  ✗ {target.get('label')}: {e}")
                 async with lock:
                     totals["fail"] += 1
-                    failed.append(target.get("url") or target.get("label"))
+                    failed.append(("track", target.get("url") or target.get("label")))
 
     await asyncio.gather(*(dl_worker(t) for t in targets), return_exceptions=True)
 

--- a/lucidadl/matching.py
+++ b/lucidadl/matching.py
@@ -89,11 +89,12 @@ def artist_matches(query: str, item: Dict[str, str]) -> bool:
 
 
 def pick_best(query: str, items: List[Dict[str, str]],
-              require_artist: bool = False) -> Optional[str]:
+              require_artist: bool = False, min_score: Optional[float] = None,
+              min_margin: float = 0.0) -> Optional[str]:
     """Return the URL of the best-scoring candidate (ties → earliest result). When
     `require_artist` is set and the query names an artist, only candidates whose artist
-    matches are considered, and None is returned if none do (so a broadened title-only
-    search can't silently pick a track by the wrong artist)."""
+    matches are considered. Optional score/margin guards let automatic downloads reject
+    a weak or ambiguous match while interactive search can keep showing every result."""
     if not items:
         return None
     pool = items
@@ -102,9 +103,13 @@ def pick_best(query: str, items: List[Dict[str, str]],
         if not matched:
             return None
         pool = matched
-    best_i, best_s = 0, None
-    for i, it in enumerate(pool):
-        sc = score(query, it)
-        if best_s is None or sc > best_s:
-            best_s, best_i = sc, i
+    ranked = sorted(enumerate(pool), key=lambda pair: score(query, pair[1]), reverse=True)
+    best_i, best_item = ranked[0]
+    best_s = score(query, best_item)
+    if min_score is not None and best_s < min_score:
+        return None
+    if len(ranked) > 1:
+        second_s = score(query, ranked[1][1])
+        if best_s - second_s < min_margin:
+            return None
     return pool[best_i].get("url")

--- a/lucidadl/paths.py
+++ b/lucidadl/paths.py
@@ -111,5 +111,5 @@ def set_music_dir(path: str) -> str:
 
 
 def cwd(name: str) -> str:
-    """A path in the current working directory (e.g. watchlist inputs)."""
+    """A path in the current working directory (e.g. default batch inputs)."""
     return os.path.join(os.getcwd(), name)

--- a/lucidadl/session.py
+++ b/lucidadl/session.py
@@ -9,8 +9,10 @@ ride the same Cloudflare clearance.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
+import sys
 import time
 from contextlib import asynccontextmanager
 from typing import AsyncIterator, Optional, Tuple
@@ -39,6 +41,26 @@ _CHALLENGE_BODY = (
 
 class BrowserClosed(RuntimeError):
     """The browser window/context closed unexpectedly."""
+
+
+async def chromium_installed() -> bool:
+    """Return whether Playwright's matching Chromium build is available."""
+    try:
+        async with async_playwright() as pw:
+            return os.path.exists(pw.chromium.executable_path)
+    except Exception:
+        return False
+
+
+async def install_chromium() -> bool:
+    """Install Chromium into the current Python/pipx environment."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable, "-m", "playwright", "install", "chromium"
+        )
+        return await proc.wait() == 0
+    except Exception:
+        return False
 
 
 def _title_is_challenge(title: str) -> bool:

--- a/lucidadl/tui.py
+++ b/lucidadl/tui.py
@@ -17,7 +17,7 @@ from . import paths, transcode
 _TO_NONE = "(none — keep the source format)"
 _SERVICES = ["qobuz", "amazon"]
 # actions whose output is worth reading before the menu redraws (we pause after them)
-_PAUSE_AFTER = {"track", "album", "playlist", "search", "watchlist", "retry"}
+_PAUSE_AFTER = {"download", "playlist", "batch", "retry", "tools", "onboarding"}
 
 
 def _isatty(stream) -> bool:
@@ -29,12 +29,20 @@ def _onoff(b: bool) -> str:
     return "yes" if b else "no"
 
 
+def _is_first_run() -> bool:
+    return not (os.path.exists(paths.CONFIG_PATH) or os.path.exists(paths.CLEARANCE_PATH))
+
+
 # --- persisted settings -----------------------------------------------------
 
 def _settings() -> dict:
     cfg = paths.load_config()
+    try:
+        jobs = max(1, min(100, int(cfg.get("jobs", 3) or 3)))
+    except (TypeError, ValueError):
+        jobs = 3
     return {
-        "jobs": int(cfg.get("jobs", 3) or 3),
+        "jobs": jobs,
         "service": cfg.get("service") if cfg.get("service") in _SERVICES else "qobuz",
         "to": cfg.get("to") or None,
         "bitrate": cfg.get("bitrate") or None,
@@ -67,9 +75,9 @@ def _opts_line(s: dict) -> str:
 
 # --- small input helpers ----------------------------------------------------
 
-def _ask_text(questionary, message: str, instruction: str = "") -> str:
+def _ask_text(questionary, message: str, instruction: str = "", default: str = "") -> str:
     """Text prompt that collapses cancel/empty/whitespace into '' (caller returns)."""
-    v = questionary.text(message, instruction=instruction).ask()
+    v = questionary.text(message, instruction=instruction, default=default).ask()
     return (v or "").strip()
 
 
@@ -88,24 +96,25 @@ def _open_path(path: str, console) -> None:
         console.print(f"[yellow]Could not open {path}: {e}[/]")
 
 
-def _append_line(path: str, line: str) -> None:
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "a", encoding="utf-8") as f:
-        f.write(line.rstrip("\n") + "\n")
-
-
-def _remove_entries(path: str, entries) -> None:
-    """Delete only the given entry lines, PRESERVING comments and blank lines (the
-    watchlist files ship with a documented header we must not wipe)."""
-    targets = set(entries)
-    try:
-        with open(path, encoding="utf-8") as f:
-            raw = f.readlines()
-    except OSError:
+def _show_run_summary(result, out: str, console) -> None:
+    """Give menu users one stable, readable outcome after the live progress output."""
+    if not result:
         return
-    kept = [ln for ln in raw if ln.strip() not in targets]
-    with open(path, "w", encoding="utf-8") as f:
-        f.writelines(kept)
+    from rich.panel import Panel
+    totals, remaining = result
+    failed = max(totals.get("fail", 0), len(remaining))
+    color = "red" if failed else "green"
+    next_step = ("\n[bold]Next:[/] choose Retry failures from the main menu."
+                 if failed else "")
+    console.print(Panel(
+        f"[green]{totals.get('ok', 0)} downloaded[/]  ·  "
+        f"{totals.get('skip', 0)} already present  ·  "
+        f"[{color}]{failed} failed[/]\n"
+        f"[dim]Files:[/] {out}{next_step}",
+        title="Download complete" if not failed else "Download incomplete",
+        border_style=color,
+        expand=False,
+    ))
 
 
 # --- main loop --------------------------------------------------------------
@@ -119,6 +128,7 @@ def run() -> None:
         import questionary
         from questionary import Choice
         from rich.console import Console
+        from rich.panel import Panel
     except Exception as e:  # pragma: no cover
         print(f"UI unavailable ({e}). Install: pip install rich questionary")
         return
@@ -126,30 +136,41 @@ def run() -> None:
     console = Console()
     from . import cli  # deferred: cli imports tui for the command
 
-    console.print("[dim]Esc cancels a field · Ctrl-C interrupts a download.[/]")
     while True:
         s = _settings()
-        console.print(f"\n[bold cyan]lucidadl[/]  ·  [dim]{_opts_line(s)}[/]\n"
-                      f"[dim]{paths.default_music_dir()}[/]")
+        access_saved = os.path.exists(paths.CLEARANCE_PATH)
+        access = "[green]prepared[/]" if access_saved else "[yellow]setup needed[/]"
+        console.print(Panel(
+            f"[bold]{_opts_line(s)}[/]\n"
+            f"[dim]Music:[/] {paths.default_music_dir()}\n"
+            f"[dim]Access:[/] {access}",
+            title="[bold cyan]lucidadl[/]", border_style="cyan", expand=False,
+        ))
 
-        menu = [
-            Choice("🎵  Download a track", "track"),
-            Choice("💿  Download an album", "album"),
-            Choice("🅰️   Import an Apple Music playlist", "playlist"),
-            Choice("🔎  Interactive search", "search"),
-            Choice("📜  Watchlists (tracks / albums)", "watchlist"),
+        if _is_first_run():
+            console.print(Panel(
+                "Welcome! Start with [bold]Set up lucidadl[/]. It checks the browser, "
+                "lets you confirm the music folder, and prepares access to lucida.to.",
+                title="First time here?", border_style="yellow", expand=False,
+            ))
+
+        menu = []
+        if not access_saved:
+            menu.append(Choice("✨  Set up lucidadl (recommended)", "onboarding"))
+        menu += [
+            Choice("⬇   Download music", "download"),
+            Choice("🎶  Import an Apple Music playlist", "playlist"),
+            Choice("📄  Download from a .txt file", "batch"),
         ]
-        failed = cli._read_lines(paths.FAILED_PATH)
+        failed = cli._read_failed()
         if failed:
             menu.append(Choice(f"🔁  Retry failures ({len(failed)})", "retry"))
         menu += [
             Choice("⚙   Settings", "settings"),
-            Choice("🛡   Prepare access (Cloudflare)", "setup"),
-            Choice("📂  Open the music folder", "openfolder"),
-            Choice("📄  View the log", "log"),
+            Choice("🧰  Help, access and diagnostics", "tools"),
             Choice("🚪  Quit", "quit"),
         ]
-        action = questionary.select("What would you like to do?", choices=menu,
+        action = questionary.select("What do you want to do?", choices=menu,
                                     qmark="►", instruction="(↑/↓, Enter)").ask()
 
         if action in (None, "quit"):
@@ -182,10 +203,20 @@ def _dispatch(action, s, console, cli, questionary) -> bool:
 
     def go(items, kind, dedup, collection=None):
         _warn_browser()
-        asyncio.run(cli._run(items, kind, s["service"], None, "original", out,
-                             hidden=False, jobs=s["jobs"], dedup=dedup, organize_on=True,
-                             to_fmt=s["to"], bitrate=s["bitrate"], keep_orig=s["keep_orig"],
-                             collection=collection, force=s["force"]))
+        result = asyncio.run(cli._run(
+            items, kind, s["service"], None, "original", out, hidden=False,
+            jobs=s["jobs"], dedup=dedup, organize_on=True, to_fmt=s["to"],
+            bitrate=s["bitrate"], keep_orig=s["keep_orig"], collection=collection,
+            force=s["force"],
+        ))
+        _show_run_summary(result, out, console)
+        return result
+
+    if action == "onboarding":
+        return _onboarding_action(console, cli, questionary)
+
+    if action == "download":
+        return _download_action(s, console, cli, questionary, go)
 
     if action == "track":
         q = _ask_text(questionary, "Track or URL:",
@@ -217,40 +248,103 @@ def _dispatch(action, s, console, cli, questionary) -> bool:
                                   keep_orig=s["keep_orig"], force=s["force"]))
         return True
 
-    if action == "search":
-        return _search_action(s, console, cli, questionary, go)
-
-    if action == "watchlist":
-        return _watchlist_action(s, console, cli, questionary, go)
+    if action == "batch":
+        return _batch_action(console, cli, questionary, go)
 
     if action == "retry":
-        items = cli._read_lines(paths.FAILED_PATH)
+        items = cli._read_failed()
         if not items:
             console.print("[yellow]No failures to retry.[/]")
             return False
-        go(items, "track", dedup=False)
+        _warn_browser()
+        result = asyncio.run(cli._retry(
+            items, s["service"], None, "original", out, hidden=False, jobs=s["jobs"],
+            organize_on=True, to_fmt=s["to"], bitrate=s["bitrate"],
+            keep_orig=s["keep_orig"], force=s["force"],
+        ))
+        _show_run_summary(result, out, console)
         return True
 
     if action == "settings":
         _settings_menu(s, console, questionary)
         return False
 
-    if action == "setup":
-        _warn_browser()
-        asyncio.run(cli._setup())
-        return False
+    if action == "tools":
+        return _tools_action(console, cli, questionary)
 
+    return False
+
+
+def _onboarding_action(console, cli, questionary) -> bool:
+    """Small first-run flow: confirm the destination, then prepare browser access."""
+    folder = paths.default_music_dir()
+    console.print(f"\nMusic will be saved in:\n[bold]{folder}[/]")
+    keep = questionary.confirm("Use this folder?", default=True).ask()
+    if keep is None:
+        return False
+    if not keep:
+        chosen = _ask_text(questionary, "Music folder:", "(empty = cancel)")
+        if not chosen:
+            return False
+        folder = paths.set_music_dir(chosen)
+        try:
+            os.makedirs(folder, exist_ok=True)
+        except Exception as e:
+            console.print(f"[red]Could not create the music folder: {e}[/]")
+            return True
+        console.print(f"[green]✓ Music folder saved: {folder}[/]")
+    console.print("\nNext, lucidadl will prepare its browser access once.")
+    return bool(asyncio.run(cli._setup()))
+
+
+def _download_action(s, console, cli, questionary, go) -> bool:
+    """Group the three everyday download paths behind one clear menu."""
+    from questionary import Choice
+    action = questionary.select("Download music:", choices=[
+        Choice("🎵  Track — enter an artist, title or URL", "track"),
+        Choice("💿  Album — enter an artist, album or URL", "album"),
+        Choice("🔎  Search — browse results before downloading", "search"),
+        Choice("← Back", "back"),
+    ]).ask()
+    if action in (None, "back"):
+        return False
+    if action == "search":
+        return _search_action(s, console, cli, questionary, go)
+    prompt = "Track or URL:" if action == "track" else "Album or URL:"
+    example = ("(e.g. Daft Punk - Around the World ; empty = back)"
+               if action == "track" else
+               "(e.g. Daft Punk - Discovery ; empty = back)")
+    value = _ask_text(questionary, prompt, example)
+    if not value:
+        return False
+    go([value], action, dedup=False)
+    return True
+
+
+def _tools_action(console, cli, questionary) -> bool:
+    from questionary import Choice
+    action = questionary.select("Help and diagnostics:", choices=[
+        Choice("🛡   Prepare or refresh access", "setup"),
+        Choice("🩺  Check the installation", "doctor"),
+        Choice("🌐  Test browser + lucida.to", "doctor-live"),
+        Choice("📂  Open the music folder", "openfolder"),
+        Choice("📄  Open the last run log", "log"),
+        Choice("← Back", "back"),
+    ]).ask()
+    if action in (None, "back"):
+        return False
+    if action == "setup":
+        return bool(asyncio.run(cli._setup()))
+    if action in ("doctor", "doctor-live"):
+        asyncio.run(cli._doctor(live=action == "doctor-live"))
+        return True
     if action == "openfolder":
         _open_path(paths.default_music_dir(), console)
         return False
-
-    if action == "log":
-        if os.path.exists(paths.LOG_PATH):
-            _open_path(paths.LOG_PATH, console)
-        else:
-            console.print("[yellow]No log yet.[/]")
-        return False
-
+    if os.path.exists(paths.LOG_PATH):
+        _open_path(paths.LOG_PATH, console)
+    else:
+        console.print("[yellow]No download log yet.[/]")
     return False
 
 
@@ -276,73 +370,51 @@ def _search_action(s, console, cli, questionary, go) -> bool:
         alb = f"  [{it.get('album')}]" if it.get("album") else ""
         choices.append(Choice(f"{tag} {it.get('title', '?')} — {it.get('artist', '?')}{alb}",
                               (kind, it)))
-    choices.append(Choice("← Cancel", None))
+    choices.append(Choice("← Cancel", "cancel"))
     pick = questionary.select("Result to download:", choices=choices).ask()
-    if not pick:
+    if pick in (None, "cancel"):
         return False
     kind, item = pick
     go([item["url"]], kind, dedup=False)
     return True
 
 
-def _watchlist_action(s, console, cli, questionary, go) -> bool:
+def _batch_action(console, cli, questionary, go) -> bool:
+    """Download a one-off batch from a user-owned text file; never edit that file."""
     from questionary import Choice
-    which = questionary.select("Which list?", choices=[
-        Choice("Tracks  (tracks.txt)", "tracks"),
-        Choice("Albums  (albums.txt)", "albums"),
-        Choice("← Back", None),
+    which = questionary.select("What does the file contain?", choices=[
+        Choice("🎵  Tracks — one search or URL per line", "tracks"),
+        Choice("💿  Albums — one search or URL per line", "albums"),
+        Choice("← Back", "back"),
     ]).ask()
-    if not which:
+    if which in (None, "back"):
         return False
     kind = "track" if which == "tracks" else "album"
-    f = os.path.join(cli.INPUTS, f"{which}.txt")
-    lines = cli._read_lines(f)
-    op = questionary.select(f"{which}.txt — {len(lines)} item(s):", choices=[
-        Choice("⬇   Download all", "dl"),
-        Choice("👁   View the list", "view"),
-        Choice("➕  Add", "add"),
-        Choice("🗑   Remove", "del"),
-        Choice("← Back", None),
-    ]).ask()
-    if not op:
+    default = os.path.abspath(os.path.join(cli.INPUTS, f"{which}.txt"))
+    raw_path = _ask_text(
+        questionary, "Text file:",
+        "(comments starting with # and blank lines are ignored; empty = back)",
+        default=default,
+    )
+    if not raw_path:
         return False
-
-    if op == "view":
-        if lines:
-            for line in lines:
-                console.print(f"  • {line}")
-        else:
-            console.print("[yellow](empty list)[/]")
+    file_path = os.path.abspath(os.path.expandvars(os.path.expanduser(
+        raw_path.strip('"'))))
+    if not os.path.isfile(file_path):
+        console.print(f"[red]File not found: {file_path}[/]")
         return True
-
-    if op == "add":
-        added = 0
-        while True:
-            it = _ask_text(questionary, "Add (artist - track/album, or URL ; empty = done):")
-            if not it:
-                break
-            _append_line(f, it)
-            added += 1
-            console.print(f"[green]+ {it}[/]")
-        if added:
-            console.print(f"[green]{added} added to {which}.txt.[/]")
-        return added > 0
-
-    if op == "del":
-        if not lines:
-            console.print("[yellow](empty list)[/]")
-            return False
-        rm = questionary.checkbox("Check (Space) the items to remove:",
-                                  choices=lines).ask()
-        if rm:
-            _remove_entries(f, rm)  # preserves comments / blank lines
-            console.print(f"[green]{len(rm)} removed.[/]")
-        return bool(rm)
-
-    # op == "dl"
+    lines = cli._read_lines(file_path)
     if not lines:
-        console.print(f"[yellow]{which}.txt is empty — add some items first.[/]")
+        console.print("[yellow]The file contains no items to download.[/]")
+        return True
+    label = "tracks" if kind == "track" else "albums"
+    confirmed = questionary.confirm(
+        f"Download {len(lines)} {label} from {os.path.basename(file_path)}?",
+        default=True,
+    ).ask()
+    if not confirmed:
         return False
+    console.print(f"[dim]The source file will not be modified: {file_path}[/]")
     go(lines, kind, dedup=True)
     return True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,21 +1,20 @@
 [build-system]
-requires = ["setuptools>=61"]
+requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "lucidadl"
-version = "1.0.0"
+version = "1.1.0"
 description = "Fast, parallel CLI music downloader for lucida.to (Qobuz, Amazon Music) with local transcoding and playlist import."
 readme = "README.md"
 requires-python = ">=3.10"
-license = { text = "MIT" }
+license = "MIT"
 authors = [{ name = "Jude-A" }]
 keywords = ["music", "downloader", "lucida", "qobuz", "amazon", "flac", "cli", "tui"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: End Users/Desktop",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",

--- a/schedule.ps1
+++ b/schedule.ps1
@@ -1,7 +1,7 @@
 <#
   Schedule lucidadl to run "in the background" on Windows.
 
-  Registers a Windows Scheduled Task that runs a watchlist (`lucida albums` or
+  Registers a Windows Scheduled Task that runs a batch file (`lucida albums` or
   `lucida tracks`) every day at a given time.
 
   IMPORTANT: the task runs only "when the user is logged on" (Interactive logon),
@@ -22,7 +22,7 @@ param(
   [string]$WorkingDir = (Get-Location).Path
 )
 
-# The watchlist (`tracks`/`albums`) reads .\inputs\<mode>.txt relative to the working
+# The batch command (`tracks`/`albums`) reads .\inputs\<mode>.txt relative to the working
 # directory, so point the task at a folder that contains your inputs\ folder.
 $lucida = (Get-Command lucida -ErrorAction SilentlyContinue).Source
 if (-not $lucida) {

--- a/selftest.py
+++ b/selftest.py
@@ -234,19 +234,7 @@ _m_sgl = _tm({}, {"title": "One More Time", "artists": [{"name": "Daft Punk"}],
 check("_track_meta single: track artist + nested album.title",
       _m_sgl["albumartist"] == "Daft Punk" and _m_sgl["album"] == "Discovery")
 
-# TUI watchlist delete must preserve comments / blank lines (data-loss fix)
 from lucidadl import tui as _tui
-_wd = tempfile.mkdtemp(prefix="lucidadl_wl_")
-_wf = _os.path.join(_wd, "tracks.txt")
-with open(_wf, "w", encoding="utf-8") as fh:
-    fh.write("# header comment\n\nArtist - Keep\nArtist - Drop\n")
-_tui._remove_entries(_wf, ["Artist - Drop"])
-with open(_wf, encoding="utf-8") as fh:
-    _wc = fh.read()
-check("watchlist delete preserves comment+blank+other, drops selected",
-      "# header comment" in _wc and "\n\n" in _wc and "Artist - Keep" in _wc
-      and "Artist - Drop" not in _wc)
-_sh.rmtree(_wd, ignore_errors=True)
 
 # matching: pick the real track over remixes / the real album over tributes
 from lucidadl import matching as _m
@@ -295,6 +283,15 @@ check("matching: wrong artist loses",
       matching.pick_best("Red Hot Chili Peppers - Otherside",
                          [{"url": "w", "title": "Otherside", "artist": "Macklemore"},
                           {"url": "r", "title": "Otherside", "artist": "Red Hot Chili Peppers"}]) == "r")
+check("matching: automatic mode rejects a wrong-artist-only result",
+      matching.pick_best("Red Hot Chili Peppers - Otherside",
+                         [{"url": "w", "title": "Otherside", "artist": "Macklemore"}],
+                         min_score=5.5, min_margin=0.25) is None)
+check("matching: automatic mode rejects tied editions",
+      matching.pick_best("Artist - Song",
+                         [{"url": "a", "title": "Song", "artist": "Artist"},
+                          {"url": "b", "title": "Song", "artist": "Artist"}],
+                         min_score=5.5, min_margin=0.25) is None)
 
 # resolver query variants (specific -> loose) + artist-gated broadening
 from lucidadl.downloader import _query_variants as _qv
@@ -361,15 +358,103 @@ async def _refresh_storm():
 _aio.run(_refresh_storm())
 check("refresh deduped to 1 browser open", _calls["n"] == 1 and _c.cf == "CF1")
 
-# playlist source detection (Apple handled separately -> None here)
-from lucidadl.api import _playlist_source, FALLBACK_SERVICES
-check("source spotify", _playlist_source("https://open.spotify.com/playlist/x")[0] == "open.spotify.com")
-check("source deezer", _playlist_source("https://www.deezer.com/fr/playlist/1")[0] == "deezer.com")
-check("source tidal", _playlist_source("https://tidal.com/browse/playlist/x")[0] == "tidal.com")
-check("source apple -> None (handled separately)",
-      _playlist_source("https://music.apple.com/fr/playlist/x/pl.1")[0] is None)
-check("source unknown -> None", _playlist_source("https://example.com/x")[0] is None)
+# fallback services remain intentionally small
+from lucidadl.api import FALLBACK_SERVICES
 check("fallback chain", "qobuz" in FALLBACK_SERVICES and "amazon" in FALLBACK_SERVICES)
+
+# first-run UX: the quick doctor must never open a browser unless --live is requested
+import contextlib as _ctxlib
+import io as _io
+from unittest.mock import AsyncMock as _AsyncMock, patch as _patch
+from click.testing import CliRunner as _CliRunner
+from lucidadl import cli as _cli
+
+with _patch.object(_cli, "chromium_installed", _AsyncMock(return_value=True)), \
+     _patch.object(_cli.transcode, "available", return_value=True), \
+     _patch.object(_cli, "load_clearance", return_value=("CF", "UA")), \
+     _patch.object(_cli, "lucida_context") as _browser_ctx:
+    _doctor_out = _io.StringIO()
+    with _ctxlib.redirect_stdout(_doctor_out):
+        _doctor_ok = _aio.run(_cli._doctor(live=False))
+check("doctor: quick check succeeds without opening a browser",
+      _doctor_ok and not _browser_ctx.called and "not run" in _doctor_out.getvalue())
+
+with _patch.object(_cli, "chromium_installed", _AsyncMock(return_value=False)), \
+     _patch.object(_cli, "install_chromium", _AsyncMock(return_value=True)) as _install, \
+     _patch.object(_cli, "acquire_clearance", _AsyncMock(return_value=("CF", "UA"))) as _access:
+    with _ctxlib.redirect_stdout(_io.StringIO()):
+        _setup_ok = _aio.run(_cli._setup())
+check("setup: installs a missing browser before preparing access",
+      _setup_ok and _install.await_count == 1 and _access.await_count == 1)
+
+with _patch.object(_tui.os.path, "exists", return_value=False):
+    check("tui: empty app data is detected as first run", _tui._is_first_run())
+
+# corrupt or hand-edited settings must not prevent the TUI from starting
+with _patch.object(_tui.paths, "load_config", return_value={"jobs": "many"}):
+    check("tui: invalid jobs setting falls back safely", _tui._settings()["jobs"] == 3)
+
+# failures preserve album/track intent, while old files stay backwards-compatible
+_failed_dir = tempfile.mkdtemp(prefix="lucidadl_failed_")
+_failed_path = _os.path.join(_failed_dir, "failed.txt")
+with _patch.object(_cli, "FAILED_PATH", _failed_path):
+    _cli._write_failed([("album", "Artist - Album"), ("track", "Artist - Song")])
+    check("retry: typed failures round-trip", _cli._read_failed() == [
+        ("album", "Artist - Album"), ("track", "Artist - Song")])
+    with open(_failed_path, "w", encoding="utf-8") as _legacy:
+        _legacy.write("Legacy Artist - Song\n")
+    check("retry: legacy failures remain track retries",
+          _cli._read_failed() == [("track", "Legacy Artist - Song")])
+
+    _retry_calls = []
+    async def _fake_retry_run(values, kind, *args, **kwargs):
+        _retry_calls.append((kind, values))
+        if kind == "track":
+            return ({"ok": 0, "skip": 0, "fail": 1}, [("track", values[0])])
+        return ({"ok": 1, "skip": 0, "fail": 0}, [])
+
+    with _patch.object(_cli, "_run", side_effect=_fake_retry_run):
+        with _ctxlib.redirect_stdout(_io.StringIO()):
+            _retry_result = _aio.run(_cli._retry(
+                [("album", "Artist - Album"), ("track", "Artist - Song")],
+                "qobuz", None, "original", _failed_dir, False, 3))
+    check("retry: albums and tracks are dispatched with their original type",
+          _retry_calls == [
+              ("track", ["Artist - Song"]), ("album", ["Artist - Album"])])
+    check("retry: only unresolved items remain",
+          _retry_result[1] == [("track", "Artist - Song")]
+          and _cli._read_failed() == [("track", "Artist - Song")])
+_sh0.rmtree(_failed_dir)
+
+# unsupported playlist URLs fail immediately without launching Playwright
+with _patch.object(_cli, "lucida_context") as _playlist_browser:
+    with _ctxlib.redirect_stdout(_io.StringIO()):
+        _unsupported_ok = _aio.run(_cli._playlist(
+            "https://example.com/list", True, "qobuz", None, "original",
+            tempfile.gettempdir(), False, 3))
+check("playlist: unsupported links fail before opening a browser",
+      not _unsupported_ok and not _playlist_browser.called)
+
+# command contracts used by scripts: missing input/search failure must be non-zero,
+# while an explicit search cancellation remains a normal successful exit
+_runner = _CliRunner()
+_missing_batch = _runner.invoke(
+    _cli.cli, ["tracks", "--file", _os.path.join(tempfile.gettempdir(),
+                                                  "lucidadl-no-such-batch.txt")])
+check("batch: missing file returns exit 1 with guidance",
+      _missing_batch.exit_code == 1 and "Batch file not found" in _missing_batch.output
+      and "--file" in _missing_batch.output)
+
+_search_failure = ({"ok": 0, "skip": 0, "fail": 1}, [])
+with _patch.object(_cli, "_search", _AsyncMock(return_value=_search_failure)):
+    _search_failed = _runner.invoke(_cli.cli, ["search", "anything"])
+check("search: failure result returns exit 1", _search_failed.exit_code == 1)
+with _patch.object(_cli, "_search", _AsyncMock(return_value=None)):
+    _search_cancelled = _runner.invoke(_cli.cli, ["search", "anything"])
+check("search: explicit cancellation returns exit 0", _search_cancelled.exit_code == 0)
+
+_help = _runner.invoke(_cli.cli, ["--help"])
+check("cli: developer debug command is hidden", "  debug " not in _help.output)
 
 print()
 if fails:


### PR DESCRIPTION
## Summary

- guide first-run setup and simplify the terminal UI
- turn text lists into explicit batch downloads without editing source files
- harden matching, retries, failure reporting, exit statuses, and transcoding fallback
- keep Apple Music as the single supported playlist source and write portable M3U8 files
- rewrite the README around the three core product flows
- prepare version 1.1.0 and modernize package metadata

## Validation

- `python selftest.py`
- Python bytecode compilation
- live Qobuz search in an interactive terminal (cancelled before download)
- public Apple Music dry run: 48/48 tracks extracted
- source distribution and wheel built successfully
- `twine check` passed for both artifacts
- wheel installed in an isolated environment; version/help/error smoke checks passed

No real audio download was triggered during this pass.