### PR TITLE
Release 1.2.0: strengthen Apple playlist workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-09-03
+
+### Added
+- `lucida playlist URL --check` resolves every Apple Music title through the normal
+  Qobuz/Amazon matching path without downloading, and clearly lists unresolved entries.
+- `lucida playlist-file FILE --name "My playlist"` turns a reviewed or edited text list
+  into the same ordered playlist folder and portable `.m3u8` output.
+- `lucida cleanup` removes stale download-state references and `.part` files older than
+  24 hours without touching completed audio.
+
+### Changed
+- Interrupted playlist downloads now retain their source order, destination, settings,
+  and collection name. `lucida retry` resumes the complete saved run while skipping files
+  already present; ordinary playlist failures retry directly into the original playlist
+  at their original track numbers.
+- Apple Music extraction now uses stable semantic page attributes alongside the existing
+  visual-list reader, with a structured-data fallback and clearer private, missing, and
+  region-unavailable diagnostics.
+- Duplicate occurrences of the same song are preserved as distinct playlist positions.
+  Existing 1.1 playlist files are recognized and migrated lazily without re-downloading.
+- Playlist `.m3u8` files are written atomically and sort track numbers numerically even
+  when an updated playlist changes its zero-padding width.
+- Temporary network and server errors use bounded retries and `Retry-After`; permanent
+  request failures stop sooner, incomplete response bodies never become finished files,
+  and common failures now include a useful next step.
+- Extracted Apple Music lists are saved under the application data directory rather than
+  silently overwriting `inputs/playlist.txt` in the current working directory.
+- The interactive playlist flow now offers download/resume, match checking, extraction,
+  and reviewed text-list import as explicit choices.
+- `lucida doctor` verifies that the music folder is writable and reports stale partial
+  files or an interrupted playlist waiting to be resumed.
+
 ## [1.1.0] - 2026-09-03
 
 ### Added
@@ -90,7 +122,8 @@ First public release.
 - **Fixed, configurable download directory** (`~/Downloads/music` by default;
   `lucida config --music`, or the `LUCIDADL_MUSIC` env var).
 
-[Unreleased]: https://github.com/Jude-A/lucidadl/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/Jude-A/lucidadl/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/Jude-A/lucidadl/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/Jude-A/lucidadl/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/Jude-A/lucidadl/compare/v0.1.1...v1.0.0
 [0.1.1]: https://github.com/Jude-A/lucidadl/compare/v0.1.0...v0.1.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,9 @@ python selftest.py        # prints "ALL OFFLINE TESTS PASSED"
 CI runs the same self-tests on Linux and Windows for Python 3.10–3.12, plus a packaging
 check (`python -m build` + `twine check`).
 
+For playlist changes, also run a public Apple Music `--dry-run`; use `--check` when the
+matching path changed. Neither command writes audio files.
+
 ### What can't be tested automatically
 
 The live flow — solving Cloudflare, downloading, and the interactive `ui` — needs a

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ commands and an interactive terminal interface.
 
 lucidadl downloads tracks and albums in parallel, organizes them from their metadata,
 can convert them locally with ffmpeg, accepts large `.txt` batches, and imports public
-Apple Music playlists. It intentionally remains a lightweight personal tool rather than
-a music-library platform.
+Apple Music playlists with match checking and reliable resume. It intentionally remains
+a lightweight personal tool rather than a music-library or streaming-account platform.
 
 > Use lucidadl only for content you are entitled to download. You are responsible for
 > complying with applicable law and with the terms of the services involved. This
@@ -26,7 +26,8 @@ a music-library platform.
 - FLAC source downloads and optional local MP3, AAC, Opus, Ogg, WAV, or FLAC conversion.
 - Tag-based organization under `Artists/<Artist>/<Album>/`.
 - Batch downloads from any `.txt` file, without modifying the source list.
-- Public Apple Music playlist import with ordered tracks and a portable `.m3u8` file.
+- Public Apple Music playlist import with match checking, resume, ordered tracks, and a
+  portable `.m3u8` file.
 - Existence-aware deduplication, safe matching, and one-command retry for failures.
 - Guided first-run setup, diagnostics, progress bars, and a compact interactive menu.
 
@@ -109,7 +110,27 @@ Preview the extraction without downloading anything:
 lucida playlist "https://music.apple.com/.../pl.xxxxxxxx" --dry-run
 ```
 
-Apple Music is currently the only supported playlist source.
+To verify what lucidadl will select on Qobuz or Amazon before starting a large download:
+
+```bash
+lucida playlist "https://music.apple.com/.../pl.xxxxxxxx" --check
+```
+
+The extracted list is saved in lucidadl's application-data folder. If a title is
+ambiguous or unavailable, edit that file (or remove the line), then download the reviewed
+version while preserving playlist order:
+
+```bash
+lucida playlist-file "C:/path/to/playlist.txt" --name "My playlist"
+```
+
+If a playlist is interrupted, `lucida retry` resumes it with its original folder,
+settings, and track numbers. Existing files are skipped, and the `.m3u8` is rebuilt when
+the run finishes. Repeating the same song at two different positions is supported.
+
+Apple Music remains the only remote playlist source. Cross-service playlist translation
+and account authorization intentionally belong in a separate companion project rather
+than in this downloader.
 
 ## Interactive menu
 
@@ -124,7 +145,7 @@ Run `lucida` without arguments (or `lucida ui`):
 
 ► What do you want to do?
   ⬇   Download music
-  🎶  Import an Apple Music playlist
+  🎶  Playlists — Apple Music or an edited list
   📄  Download from a .txt file
   ⚙   Settings
   🧰  Help, access and diagnostics
@@ -193,13 +214,14 @@ again and refreshes it.
 lucida doctor          # quick local check; never opens a browser
 lucida doctor --live   # browser and lucida.to connectivity check
 lucida setup           # install/repair Chromium and refresh access
-lucida retry           # retry only unresolved items from the previous run
+lucida retry           # retry failures or resume an interrupted playlist
+lucida cleanup         # prune stale state and old partial downloads
 ```
 
-Failed tracks and albums retain their original type. Automated and scheduled commands
-return a non-zero status while work remains unresolved. The latest details are stored in
-`run.log`; `lucida config` prints its exact location along with all other application
-paths.
+Failed tracks and albums retain their original type; playlist failures also retain their
+folder and original position. Automated and scheduled commands return a non-zero status
+while work remains unresolved. The latest details are stored in `run.log`; `lucida
+config` prints its exact location along with the extracted playlist and recovery data.
 
 Common fixes:
 
@@ -223,8 +245,8 @@ renewed.
 
 ## Application data
 
-The browser profile, access data, configuration, deduplication state, last log, and
-failed-item list are stored outside the repository:
+The browser profile, access data, configuration, deduplication state, last log,
+failed-item list, and playlist recovery data are stored outside the repository:
 
 - Windows: `%LOCALAPPDATA%\lucidadl`
 - Linux: `~/.local/share/lucidadl`

--- a/lucidadl/__init__.py
+++ b/lucidadl/__init__.py
@@ -1,3 +1,3 @@
 """lucidadl — automated music downloader driving lucida.to through a real browser."""
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"

--- a/lucidadl/api.py
+++ b/lucidadl/api.py
@@ -16,10 +16,12 @@ lucida service — so it's a module function taking a Playwright page.
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import re
 import time
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
 
 from . import paths, utils
 
@@ -50,6 +52,14 @@ class LucidaError(RuntimeError):
     pass
 
 
+def _retry_delay(response, attempt: int) -> int:
+    """Small bounded backoff, honoring Retry-After when a server supplies it."""
+    try:
+        return min(30, max(1, int(response.headers.get("Retry-After", ""))))
+    except (TypeError, ValueError):
+        return min(8, 2 ** attempt)
+
+
 def normalize_service(service: str) -> str:
     s = (service or "").lower()
     return SERVICE_ALIASES.get(s, s)
@@ -57,6 +67,14 @@ def normalize_service(service: str) -> str:
 
 def default_country(service: str) -> str:
     return COUNTRY_DEFAULTS.get(normalize_service(service), "US")
+
+
+def is_apple_playlist_url(url: str) -> bool:
+    parsed = urlparse((url or "").strip())
+    host = (parsed.hostname or "").lower()
+    parts = [part.lower() for part in parsed.path.split("/") if part]
+    return ((host == "music.apple.com" or host.endswith(".music.apple.com")) and
+            "playlist" in parts)
 
 
 class LucidaClient:
@@ -128,11 +146,26 @@ class LucidaClient:
             return True
 
     async def _get(self, url: str, **kw):
-        """GET with one Cloudflare-refresh retry on 403."""
-        r = await self.http.get(url, **kw)
-        if r.status_code == 403 and await self._refresh_creds():
-            r = await self.http.get(url, **kw)
-        return r
+        """GET with one Cloudflare refresh and bounded transient retries."""
+        refreshed = False
+        for attempt in range(3):
+            try:
+                r = await self.http.get(url, **kw)
+            except Exception:
+                if attempt == 2:
+                    raise
+                await asyncio.sleep(2 ** attempt)
+                continue
+            if r.status_code == 403 and not refreshed:
+                refreshed = True
+                if await self._refresh_creds():
+                    continue
+            if r.status_code == 429 or r.status_code in (500, 502, 503, 504):
+                if attempt < 2:
+                    await asyncio.sleep(_retry_delay(r, attempt))
+                    continue
+            return r
+        raise LucidaError("GET failed after retrying")
 
     # -- search (httpx) ------------------------------------------------------
 
@@ -199,13 +232,23 @@ class LucidaClient:
                       "secondary": track.get("csrfFallback")},
             "upload": {"enabled": False}, "url": track["url"],
         }
+        last_error = "/api/load failed"
+        refreshed = False
         for attempt in range(5):
-            r = await self.http.post(LUCIDA + "/api/load", params={"url": STREAM_ACTION}, json=body)
-            if r.status_code == 403:
-                if not await self._refresh_creds():
+            try:
+                r = await self.http.post(
+                    LUCIDA + "/api/load", params={"url": STREAM_ACTION}, json=body)
+            except Exception as exc:
+                last_error = f"/api/load network error: {exc}"
+                if attempt == 4:
                     break
-                await asyncio.sleep(2)
+                await asyncio.sleep(min(8, 2 ** attempt))
                 continue
+            if r.status_code == 403 and not refreshed:
+                refreshed = True
+                if await self._refresh_creds():
+                    await asyncio.sleep(1)
+                    continue
             try:
                 j = r.json()
             except Exception:
@@ -213,9 +256,12 @@ class LucidaClient:
             if r.status_code == 200 and j.get("handoff") and j.get("server"):
                 return j["handoff"], j["server"]
             err = (j.get("error") if isinstance(j, dict) else None) or r.text[:150]
+            last_error = f"/api/load HTTP {r.status_code}: {err}"
             self.log(f"    /api/load ({r.status_code}): {err}")
-            await asyncio.sleep(5)
-        raise LucidaError("/api/load failed")
+            if r.status_code in (400, 401, 404, 422) or (r.status_code == 403 and refreshed):
+                break
+            await asyncio.sleep(_retry_delay(r, attempt))
+        raise LucidaError(last_error)
 
     async def run_job(self, handoff: str, server: str, dest_dir: str, base_name: str,
                       title: str = "", timeout: int = 1800,
@@ -225,9 +271,19 @@ class LucidaClient:
         last_msg = None
         last_state = None
         last_change = time.time()
+        transient_errors = 0
         while time.time() < deadline:
             s = await self.http.get(base)
-            if s.status_code in (404, 500):
+            if s.status_code == 429 or s.status_code in (500, 502, 503, 504):
+                transient_errors += 1
+                if transient_errors > 3:
+                    raise LucidaError(f"poll HTTP {s.status_code} after retrying")
+                if on_status:
+                    on_status(f"server HTTP {s.status_code} — retrying")
+                await asyncio.sleep(_retry_delay(s, transient_errors - 1))
+                continue
+            transient_errors = 0
+            if s.status_code == 404:
                 raise LucidaError(f"poll HTTP {s.status_code}")
             try:
                 st = s.json()
@@ -277,9 +333,11 @@ class LucidaClient:
                 with open(part, "wb") as f:
                     async for chunk in resp.aiter_bytes(1 << 16):
                         f.write(chunk)
+                        done += len(chunk)
                         if on_bytes:
-                            done += len(chunk)
                             on_bytes(done, total)
+                if total is not None and done != total:
+                    raise LucidaError(f"incomplete download ({done}/{total} bytes)")
                 os.replace(part, _long(dest))
             except BaseException as e:  # OSError, httpx errors, CancelledError…
                 self._claimed.discard(dest)  # free the name so a retry reuses it
@@ -348,14 +406,19 @@ def _find_results_node(obj: Any, depth: int = 0) -> Optional[Dict[str, Any]]:
 
 # --- Apple Music playlist scraping (needs a Playwright page) ----------------
 
-_APPLE_ROWS_JS = """() => Array.from(document.querySelectorAll('.songs-list-row')).map(r => {
-  const n = r.querySelector('.songs-list-row__song-name');
-  const b = r.querySelector('.songs-list-row__by-line');
-  return { title: n ? n.textContent : '', artist: b ? b.textContent : '' };
+_APPLE_ROWS_JS = """() => Array.from(document.querySelectorAll(
+  '[data-testid="track-list-item"], .songs-list-row'
+)).map(r => {
+  const n = r.querySelector('[data-testid="track-title"], .songs-list-row__song-name');
+  const b = r.querySelector('[data-testid="track-column-secondary"] a, '
+    + '[data-testid="track-title-by-line"] a, .songs-list-row__by-line a, '
+    + '.songs-list-row__by-line');
+  return { index: r.dataset.row || '', title: n ? n.textContent : '',
+    artist: b ? b.textContent : '' };
 })"""
 
 _APPLE_SCROLL_JS = """() => {
-  let el = document.querySelector('.songs-list-row');
+  let el = document.querySelector('[data-testid="track-list-item"], .songs-list-row');
   while (el) {
     const s = getComputedStyle(el);
     if (/(auto|scroll)/.test(s.overflowY) && el.scrollHeight > el.clientHeight + 10) break;
@@ -376,11 +439,18 @@ async def applemusic_tracklist(page, url: str, log=print):
     await page.wait_for_timeout(1500)
     await _dismiss_consent(page)
     try:
-        await page.wait_for_selector(".songs-list-row", timeout=30_000)
+        await page.wait_for_selector(
+            '[data-testid="track-list-item"], .songs-list-row', timeout=30_000
+        )
     except Exception:
         pass
 
     name = await _playlist_name(page)
+    structured_name, structured_tracks = await _apple_structured_playlist(page)
+    if structured_name and (not name or name.lower() in ("apple music", "playlist")):
+        name = structured_name
+    if structured_tracks:
+        log(f"    ✓ {len(structured_tracks)} titles found in Apple page data")
     tracks: List[Dict[str, str]] = []
     seen = set()
     stable = 0
@@ -395,7 +465,9 @@ async def applemusic_tracklist(page, url: str, log=print):
             artist = (t.get("artist") or "").strip()
             if not title:
                 continue
-            key = (artist.lower(), title.lower())
+            row_index = str(t.get("index") or "").strip()
+            key = (("row", row_index) if row_index else
+                   ("track", artist.casefold(), title.casefold()))
             if key not in seen:
                 seen.add(key)
                 tracks.append({"title": title, "artist": artist})
@@ -411,7 +483,63 @@ async def applemusic_tracklist(page, url: str, log=print):
         stable = stable + 1 if new == 0 else 0
         if (at_bottom and stable >= 3) or stable >= 30:
             break
+    # Apple has used both a complete JSON bootstrap and a virtualized visual list over
+    # time. Keep both readers and prefer whichever produced the most complete sequence.
+    if len(structured_tracks) > len(tracks):
+        tracks = structured_tracks
     return name, tracks
+
+
+async def _apple_structured_playlist(page) -> Tuple[str, List[Dict[str, str]]]:
+    """Read JSON bootstrap scripts without depending on Apple's CSS class names."""
+    try:
+        scripts = await page.locator('script[type="application/json"]').all_text_contents()
+    except Exception:
+        return "", []
+    return _apple_playlist_from_scripts(scripts)
+
+
+def _apple_playlist_from_scripts(scripts: List[str]) -> Tuple[str, List[Dict[str, str]]]:
+    best_name, best_tracks = "", []
+    for raw in scripts or []:
+        if not raw or len(raw) > 20_000_000:  # avoid pathological pages / support dumps
+            continue
+        try:
+            obj = json.loads(raw)
+        except (TypeError, ValueError):
+            continue
+        name, tracks = _apple_playlist_from_obj(obj)
+        if len(tracks) > len(best_tracks):
+            best_name, best_tracks = name, tracks
+    return best_name, best_tracks
+
+
+def _apple_playlist_from_obj(obj: Any) -> Tuple[str, List[Dict[str, str]]]:
+    """Find the most complete playlist resource inside an Apple bootstrap object."""
+    candidates: List[Tuple[str, List[Dict[str, str]]]] = []
+
+    def visit(value: Any, depth: int = 0) -> None:
+        if depth > 40:
+            return
+        if isinstance(value, dict):
+            resource_type = str(value.get("type") or "").lower()
+            attrs = value.get("attributes") if isinstance(value.get("attributes"), dict) else {}
+            if resource_type in ("playlists", "library-playlists"):
+                extracted: List[Dict[str, str]] = []
+                relationships = value.get("relationships") or {}
+                track_rel = relationships.get("tracks") if isinstance(relationships, dict) else {}
+                data = track_rel.get("data") if isinstance(track_rel, dict) else None
+                _apple_tracks_from_obj(data, extracted)
+                if extracted:
+                    candidates.append((str(attrs.get("name") or "").strip(), extracted))
+            for child in value.values():
+                visit(child, depth + 1)
+        elif isinstance(value, list):
+            for child in value:
+                visit(child, depth + 1)
+
+    visit(obj)
+    return max(candidates, key=lambda candidate: len(candidate[1])) if candidates else ("", [])
 
 
 async def _playlist_name(page) -> str:
@@ -452,15 +580,37 @@ async def _dismiss_consent(page) -> None:
 
 async def playlist_tracklist(page, url: str, log=print):
     """Scrape a public Apple Music playlist -> (name, [{title, artist}])."""
-    from urllib.parse import urlparse
-    host = (urlparse(url).hostname or "").lower()
-    if host != "music.apple.com" and not host.endswith(".music.apple.com"):
+    if not is_apple_playlist_url(url):
         log("  unsupported playlist URL — paste a public music.apple.com playlist link")
         return "", []
     name, tracks = await applemusic_tracklist(page, url, log)
     if not tracks:
+        log("  " + await _apple_failure_reason(page))
         await _dump_playlist_debug(page)
     return name, tracks
+
+
+async def _apple_failure_reason(page) -> str:
+    """Best-effort explanation without relying on one locale or one page layout."""
+    try:
+        text = ((await page.title()) + "\n" + (await page.locator("body").inner_text())).lower()
+    except Exception:
+        return "Apple Music returned no readable playlist content."
+    unavailable = (
+        "not available in your country", "not available in your region",
+        "indisponible dans votre pays", "indisponible dans votre région",
+        "item not available", "contenu indisponible",
+    )
+    missing = (
+        "playlist not found", "page not found", "playlist introuvable",
+        "page introuvable", "content is no longer available",
+    )
+    if any(marker in text for marker in unavailable):
+        return "This playlist is unavailable in the current Apple Music region."
+    if any(marker in text for marker in missing):
+        return "This playlist no longer exists or is not publicly accessible."
+    return ("No public tracks were found. The playlist may be empty/private, or Apple "
+            "may have changed the page format.")
 
 
 async def _dump_playlist_debug(page) -> None:

--- a/lucidadl/cli.py
+++ b/lucidadl/cli.py
@@ -3,16 +3,21 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import sys
+import time
 import traceback
 from typing import Dict, List, Optional, Tuple
 
 import click
 
+from . import __version__
 from . import api, organize, paths, progress, transcode, utils
-from .api import LucidaClient, default_country, normalize_service, DOWNSCALE_CHOICES, LUCIDA
-from .downloader import run_batch
+from .api import (LucidaClient, default_country, normalize_service, DOWNSCALE_CHOICES,
+                  is_apple_playlist_url, LUCIDA)
+from .downloader import preview_tracks, run_batch
+from .models import FailedItem
 from .session import (lucida_context, ensure_cleared, get_page, BrowserClosed,
                       acquire_clearance, load_clearance, chromium_installed,
                       install_chromium)
@@ -25,10 +30,18 @@ DEFAULT_OUT = paths.default_music_dir()
 INPUTS = paths.cwd("inputs")
 LOG_PATH = paths.LOG_PATH
 FAILED_PATH = paths.FAILED_PATH
+PLAYLIST_RUN_PATH = paths.PLAYLIST_RUN_PATH
+PLAYLIST_TEXT_PATH = paths.PLAYLIST_TEXT_PATH
 
 
-FailedItem = Tuple[str, str]
 RunResult = Tuple[Dict[str, int], List[FailedItem]]
+
+
+def _as_failed_item(value) -> FailedItem:
+    if isinstance(value, FailedItem):
+        return value
+    parts = list(value) if isinstance(value, (tuple, list)) else ["track", str(value)]
+    return FailedItem(*(parts + ["", ""])[:4])
 
 
 def _write_failed(items: List[FailedItem]) -> None:
@@ -41,14 +54,17 @@ def _write_failed(items: List[FailedItem]) -> None:
             return
         with open(FAILED_PATH, "w", encoding="utf-8") as f:
             f.write("# Failed items — re-run with: lucidadl retry\n")
-            f.write("# kind<TAB>query or URL\n")
-            f.writelines(f"{kind}\t{item}\n" for kind, item in items)
+            f.write("# kind<TAB>query or URL<TAB>playlist<TAB>track number\n")
+            for raw in items:
+                item = _as_failed_item(raw)
+                f.write(f"{item.kind}\t{item.item}\t{item.collection}\t{item.track_no}\n")
     except Exception as e:
         # don't fail silently: the user is told to `retry`, but the list wasn't saved.
         click.secho(f"⚠ couldn't write {FAILED_PATH} ({e}) — `retry` won't have these "
                     f"items. Re-run them manually:", fg="yellow")
-        for kind, item in items:
-            click.echo(f"    {kind}: {item}")
+        for raw in items:
+            item = _as_failed_item(raw)
+            click.echo(f"    {item.kind}: {item.item}")
 
 _CLOSED_HINT = (
     "The browser closed on its own. Try: (1) re-run; (2) close any open Chrome "
@@ -72,12 +88,85 @@ def _read_failed() -> List[FailedItem]:
     """Read typed failures; old untyped failed.txt entries remain track retries."""
     out: List[FailedItem] = []
     for line in _read_lines(FAILED_PATH):
-        kind, sep, item = line.partition("\t")
-        if sep and kind in ("track", "album") and item:
-            out.append((kind, item))
+        parts = line.split("\t")
+        kind = parts[0] if parts else ""
+        item = parts[1] if len(parts) > 1 else ""
+        if kind in ("track", "album") and item:
+            out.append(FailedItem(kind, item,
+                                  parts[2] if len(parts) > 2 else "",
+                                  parts[3] if len(parts) > 3 else ""))
         else:
-            out.append(("track", line))
+            out.append(FailedItem("track", line))
     return out
+
+
+def _load_playlist_run() -> dict:
+    try:
+        with open(PLAYLIST_RUN_PATH, encoding="utf-8") as handle:
+            value = json.load(handle)
+        return value if isinstance(value, dict) else {}
+    except Exception:
+        return {}
+
+
+def _save_playlist_run(value: dict) -> None:
+    value = dict(value)
+    value["updated_at"] = int(time.time())
+    tmp = PLAYLIST_RUN_PATH + f".{os.getpid()}.tmp"
+    with open(tmp, "w", encoding="utf-8") as handle:
+        json.dump(value, handle, ensure_ascii=False, indent=2)
+    os.replace(tmp, PLAYLIST_RUN_PATH)
+
+
+def _pending_playlist_run() -> dict:
+    value = _load_playlist_run()
+    return value if value.get("status") == "running" and value.get("tracks") else {}
+
+
+def _playlist_run_options(value: dict) -> dict:
+    """Validated options from a saved run; corrupt values fall back conservatively."""
+    opts = value.get("options") if isinstance(value.get("options"), dict) else {}
+    try:
+        jobs = max(1, min(100, int(opts.get("jobs", 3))))
+    except (TypeError, ValueError):
+        jobs = 3
+    return {
+        "service": opts.get("service") or "qobuz",
+        "country": opts.get("country"),
+        "downscale": opts.get("downscale") or "original",
+        "out": opts.get("out") or paths.default_music_dir(),
+        "hidden": bool(opts.get("hidden", False)),
+        "jobs": jobs,
+        "organize_on": bool(opts.get("organize_on", True)),
+        "to_fmt": opts.get("to_fmt") or None,
+        "bitrate": opts.get("bitrate") or None,
+        "keep_orig": bool(opts.get("keep_orig", False)),
+        "force": bool(opts.get("force", False)),
+    }
+
+
+async def _resume_playlist_run(value: dict) -> RunResult:
+    tracks = value.get("tracks") if isinstance(value.get("tracks"), list) else []
+    items = [str(item.get("query") or "") for item in tracks if isinstance(item, dict)]
+    numbers = [str(item.get("track_no") or "") for item in tracks if isinstance(item, dict)]
+    if not items or any(not item for item in items):
+        click.secho("The saved playlist run is unreadable; paste its URL again.", fg="red")
+        return _failed_result(["saved playlist"], "track")
+    opts = _playlist_run_options(value)
+    collection = str(value.get("collection") or "Playlist")
+    click.secho(f'Resuming playlist "{collection}" ({len(items)} tracks)…', fg="cyan")
+    result = await _run(
+        items, "track", opts["service"], opts["country"], opts["downscale"],
+        opts["out"], opts["hidden"], opts["jobs"], dedup=True,
+        organize_on=opts["organize_on"], to_fmt=opts["to_fmt"],
+        bitrate=opts["bitrate"], keep_orig=opts["keep_orig"],
+        collection=collection, force=opts["force"], quiet_resolve=True,
+        track_numbers=numbers,
+    )
+    value["status"] = "incomplete" if result[0]["fail"] or result[1] else "complete"
+    value["summary"] = result[0]
+    _save_playlist_run(value)
+    return result
 
 
 def _read_batch(path: str, label: str) -> List[str]:
@@ -92,8 +181,17 @@ def _read_batch(path: str, label: str) -> List[str]:
     return items
 
 
-def _failed_result(items: List[str], kind: str) -> RunResult:
-    return ({"ok": 0, "skip": 0, "fail": len(items)}, [(kind, item) for item in items])
+def _failed_result(items: List[str], kind: str, collection: Optional[str] = None,
+                   track_numbers: Optional[List[str]] = None) -> RunResult:
+    failed = [
+        FailedItem(
+            kind, item, collection or "",
+            str(track_numbers[index])
+            if collection and track_numbers and index < len(track_numbers) else "",
+        )
+        for index, item in enumerate(items)
+    ]
+    return {"ok": 0, "skip": 0, "fail": len(items)}, failed
 
 
 def _exit_if_failed(result: RunResult) -> None:
@@ -132,7 +230,7 @@ def _service_opts(f):
 
 
 @click.group(invoke_without_command=True)
-@click.version_option(message="lucidadl %(version)s")
+@click.version_option(version=__version__, message="lucidadl %(version)s")
 @click.pass_context
 def cli(ctx):
     """Parallel-HTTP lucida.to downloader (browser only needed for Cloudflare).
@@ -157,7 +255,8 @@ async def _run(items: List[str], kind: str, service: str, country: Optional[str]
                organize_on: bool = True, to_fmt: Optional[str] = None,
                bitrate: Optional[str] = None, keep_orig: bool = False,
                collection: Optional[str] = None, force: bool = False,
-               quiet_resolve: bool = False, save_failures: bool = True) -> RunResult:
+               quiet_resolve: bool = False, save_failures: bool = True,
+               track_numbers: Optional[List[str]] = None) -> RunResult:
     if not items:
         click.secho("Nothing to download.", fg="yellow")
         return {"ok": 0, "skip": 0, "fail": 0}, []
@@ -172,7 +271,7 @@ async def _run(items: List[str], kind: str, service: str, country: Optional[str]
         if not transcode.available():
             click.secho("⚠ ffmpeg not found — install it (pip install imageio-ffmpeg) "
                         "or drop --to.", fg="red")
-            result = _failed_result(items, kind)
+            result = _failed_result(items, kind, collection, track_numbers)
             if save_failures:
                 _write_failed(result[1])
             return result
@@ -185,7 +284,7 @@ async def _run(items: List[str], kind: str, service: str, country: Optional[str]
     logf = open(LOG_PATH, "w", encoding="utf-8")
     reporter = progress.make_reporter(echo=click.echo, logfile=logf)
     log = reporter.log
-    result = _failed_result(items, kind)
+    result = _failed_result(items, kind, collection, track_numbers)
 
     log(f"# lucidadl — kind={kind} service={service} country={cc!r} "
         f"format={downscale} jobs={jobs} dedup={dedup} "
@@ -220,7 +319,8 @@ async def _run(items: List[str], kind: str, service: str, country: Optional[str]
             totals, failed = await run_batch(client, state, items, kind, service, cc, out,
                                              jobs, dedup, organize_on, tx,
                                              collection=collection, reporter=reporter,
-                                             quiet_resolve=quiet_resolve)
+                                             quiet_resolve=quiet_resolve,
+                                             track_numbers=track_numbers)
         finally:
             await client.aclose()
         log(f"\nDone — OK:{totals['ok']}  skipped:{totals['skip']}  failed:{totals['fail']}")
@@ -312,7 +412,12 @@ def albums_cmd(file, service, country, downscale, out, organize_on, jobs,
 @_service_opts
 def retry_cmd(service, country, downscale, out, organize_on, jobs, to_fmt,
               bitrate, keep_orig, force, hidden):
-    """Re-run the failed items from the last run (failed.txt)."""
+    """Resume an interrupted playlist or re-run the last failed items."""
+    pending = _pending_playlist_run()
+    if pending:
+        result = asyncio.run(_resume_playlist_run(pending))
+        _exit_if_failed(result)
+        return
     items = _read_failed()
     if not items:
         click.secho("No failures to re-run (failed.txt is empty).", fg="yellow")
@@ -330,20 +435,43 @@ async def _retry(items: List[FailedItem], service: str, country: Optional[str],
     """Retry failures by their original type, then keep only what still failed."""
     totals = {"ok": 0, "skip": 0, "fail": 0}
     remaining: List[FailedItem] = []
-    for kind in ("track", "album"):
-        values = [item for item_kind, item in items if item_kind == kind]
-        if not values:
+    normalized = [_as_failed_item(item) for item in items]
+    manifest = _load_playlist_run()
+    groups = {}
+    for item in normalized:
+        groups.setdefault((item.kind, item.collection), []).append(item)
+    for (kind, collection), group in groups.items():
+        values = [item.item for item in group]
+        if not values or kind not in ("track", "album"):
             continue
-        click.secho(f"\nRetrying {len(values)} {kind}{'s' if len(values) != 1 else ''}…",
-                    fg="cyan")
-        result = await _run(values, kind, service, country, downscale, out, hidden, jobs,
-                            dedup=True, organize_on=organize_on, to_fmt=to_fmt,
-                            bitrate=bitrate, keep_orig=keep_orig, force=force,
-                            save_failures=False)
+        label = f' in playlist "{collection}"' if collection else ""
+        click.secho(
+            f"\nRetrying {len(values)} {kind}{'s' if len(values) != 1 else ''}{label}…",
+            fg="cyan",
+        )
+        saved = (_playlist_run_options(manifest)
+                 if collection and manifest.get("collection") == collection else {})
+        result = await _run(values, kind, saved.get("service", service),
+                            saved.get("country", country), saved.get("downscale", downscale),
+                            saved.get("out", out), saved.get("hidden", hidden),
+                            saved.get("jobs", jobs), dedup=True,
+                            organize_on=saved.get("organize_on", organize_on),
+                            to_fmt=saved.get("to_fmt", to_fmt),
+                            bitrate=saved.get("bitrate", bitrate),
+                            keep_orig=saved.get("keep_orig", keep_orig),
+                            force=saved.get("force", force),
+                            collection=collection or None, save_failures=False,
+                            track_numbers=[item.track_no for item in group]
+                            if collection else None)
         for key in totals:
             totals[key] += result[0][key]
         remaining.extend(result[1])
     _write_failed(remaining)
+    if (manifest.get("status") == "incomplete" and manifest.get("collection") and
+            not any(item.collection == manifest.get("collection") for item in remaining)):
+        manifest["status"] = "complete"
+        manifest["summary"] = totals
+        _save_playlist_run(manifest)
     if not remaining:
         click.secho("\n✓ All previous failures were resolved.", fg="green")
     return totals, remaining
@@ -472,17 +600,127 @@ def _render_playlist(collection: str, tracks: list, dry_run: bool) -> None:
                       f'·  →  [dim]Playlists/{coll}/[/]\n')
 
 
-async def _playlist(url, dry_run, service, country, downscale, out, hidden,
-                    jobs, organize_on=True, to_fmt=None, bitrate=None, keep_orig=False,
-                    force=False) -> bool:
-    from urllib.parse import urlparse
+def _render_playlist_check(collection: str, rows: list) -> None:
+    matched = sum(row.get("status") == "matched" for row in rows)
+    missing = len(rows) - matched
+    console = None
+    try:
+        from rich.console import Console
+        candidate = Console()
+        if candidate.is_terminal:
+            console = candidate
+    except Exception:
+        pass
+    if console is None:
+        click.echo(f'Match check for "{collection}" — {matched} ready, {missing} unresolved')
+        for row in rows:
+            mark = "OK" if row.get("status") == "matched" else "MISS"
+            detail = (f"{row.get('artist')} - {row.get('title')}"
+                      if row.get("status") == "matched" else
+                      (row.get("error") or row.get("status")))
+            click.echo(f"  {row['index']:>3}. {mark:<4} {row['query']} → {detail}")
+        return
+    from rich.markup import escape
+    from rich.table import Table
+    table = Table(title=f'Match check — {escape(collection)}', box=None, pad_edge=False)
+    table.add_column("#", justify="right", style="dim", width=4)
+    table.add_column("Status", width=9)
+    table.add_column("Requested")
+    table.add_column("Matched on lucida")
+    for row in rows:
+        ok = row.get("status") == "matched"
+        matched_text = (f"{row.get('artist')} - {row.get('title')}" if ok else
+                        (row.get("error") or row.get("status") or "unresolved"))
+        table.add_row(str(row["index"]), "[green]ready[/]" if ok else "[red]unresolved[/]",
+                      escape(row["query"]), escape(matched_text))
+    console.print(table)
+    console.print(f"[green]{matched} ready[/]  ·  "
+                  f"[{'red' if missing else 'green'}]{missing} unresolved[/]")
 
-    host = (urlparse(url).hostname or "").lower()
-    if host != "music.apple.com" and not host.endswith(".music.apple.com"):
+
+async def _check_playlist_matches(collection: str, items: List[str], service: str,
+                                  country: Optional[str], hidden: bool, jobs: int,
+                                  edit_path: Optional[str] = None) -> bool:
+    cc = country or default_country(service)
+    cf, ua = load_clearance()
+    if not (cf and ua):
+        click.echo("Preparing lucida.to access for the match check…")
+        try:
+            cf, ua = await acquire_clearance(hidden=hidden)
+        except Exception as exc:
+            click.secho(f"Could not prepare lucida.to access: {exc}", fg="red")
+            return False
+
+    async def _acquire():
+        return await acquire_clearance(hidden=hidden)
+
+    client = LucidaClient(cf, ua, acquire=_acquire, country=cc, jobs=jobs, log=click.echo)
+    try:
+        await client.start_http()
+        rows = await preview_tracks(client, items, service, cc, jobs=jobs, log=click.echo)
+    except Exception as exc:
+        click.secho(f"Match check failed: {exc}", fg="red")
+        return False
+    finally:
+        await client.aclose()
+    _render_playlist_check(collection, rows)
+    unresolved = sum(row.get("status") != "matched" for row in rows)
+    if unresolved:
+        editable = edit_path or PLAYLIST_TEXT_PATH
+        click.secho(
+            f"Edit {editable}, then download the corrected list with:\n"
+            f'  lucida playlist-file "{editable}" --name "{collection}"',
+            fg="yellow",
+        )
+    return unresolved == 0
+
+
+async def _download_playlist_items(collection: str, items: List[str], source: str,
+                                   service: str, country: Optional[str], downscale: str,
+                                   out: str, hidden: bool, jobs: int,
+                                   organize_on: bool = True, to_fmt=None, bitrate=None,
+                                   keep_orig: bool = False, force: bool = False,
+                                   tracks: Optional[List[dict]] = None) -> bool:
+    pad = max(2, len(str(len(items))))
+    track_numbers = [f"{index:0{pad}d}" for index in range(1, len(items) + 1)]
+    track_rows = tracks or [{} for _ in items]
+    manifest = {
+        "version": 1, "status": "running", "source_url": source,
+        "collection": collection,
+        "tracks": [{"track_no": number, "artist": track.get("artist", ""),
+                    "title": track.get("title", ""), "query": item}
+                   for number, track, item in zip(track_numbers, track_rows, items)],
+        "options": {
+            "service": service, "country": country, "downscale": downscale,
+            "out": os.path.abspath(out), "hidden": hidden, "jobs": jobs,
+            "organize_on": organize_on, "to_fmt": to_fmt, "bitrate": bitrate,
+            "keep_orig": keep_orig, "force": force,
+        },
+    }
+    try:
+        _save_playlist_run(manifest)
+    except Exception as e:
+        click.secho(f"Could not save playlist recovery data: {e}", fg="yellow")
+    result = await _run(items, "track", service, country, downscale, out, hidden, jobs,
+                        dedup=True, organize_on=organize_on, to_fmt=to_fmt,
+                        bitrate=bitrate, keep_orig=keep_orig, collection=collection,
+                        force=force, quiet_resolve=True, track_numbers=track_numbers)
+    manifest["status"] = "incomplete" if result[0]["fail"] or result[1] else "complete"
+    manifest["summary"] = result[0]
+    try:
+        _save_playlist_run(manifest)
+    except Exception as e:
+        click.secho(f"Could not update playlist recovery data: {e}", fg="yellow")
+    return not (result[0]["fail"] or result[1])
+
+
+async def _playlist(url, dry_run, service, country, downscale, out, hidden,
+                     jobs, organize_on=True, to_fmt=None, bitrate=None, keep_orig=False,
+                     force=False, check_matches=False) -> bool:
+    if not is_apple_playlist_url(url):
         click.secho("Only public Apple Music playlist links are supported.", fg="red")
         return False
 
-    cc = country or default_country(service)
     name, tracks = "", []
 
     async def _scrape(headless: bool):
@@ -520,34 +758,73 @@ async def _playlist(url, dry_run, service, country, downscale, out, hidden,
     collection = name or "Playlist"
     items = [f"{t['artist']} - {t['title']}" for t in tracks]
     try:
-        os.makedirs(INPUTS, exist_ok=True)
-        with open(os.path.join(INPUTS, "playlist.txt"), "w", encoding="utf-8") as f:
+        with open(PLAYLIST_TEXT_PATH, "w", encoding="utf-8") as f:
             f.write("\n".join(items) + "\n")
-    except Exception:
-        pass
+    except Exception as e:
+        click.secho(f"Could not save the extracted list: {e}", fg="yellow")
 
     _render_playlist(collection, tracks, dry_run)
     if dry_run:
-        click.secho("--dry-run: nothing downloaded (list saved to inputs/playlist.txt).",
+        click.secho(f"--dry-run: nothing downloaded (list saved to {PLAYLIST_TEXT_PATH}).",
                     fg="yellow")
         return True
-    result = await _run(items, "track", service, country, downscale, out, hidden, jobs,
-                        dedup=True, organize_on=organize_on, to_fmt=to_fmt,
-                        bitrate=bitrate, keep_orig=keep_orig, collection=collection,
-                        force=force, quiet_resolve=True)
-    return not (result[0]["fail"] or result[1])
+    if check_matches:
+        click.secho("Checking automatic matches without downloading…", fg="cyan")
+        return await _check_playlist_matches(collection, items, service, country, hidden, jobs)
+    return await _download_playlist_items(
+        collection, items, url, service, country, downscale, out, hidden, jobs,
+        organize_on, to_fmt, bitrate, keep_orig, force, tracks,
+    )
 
 
 @cli.command("playlist")
 @click.argument("url")
 @click.option("--dry-run", is_flag=True, help="List the tracks without downloading.")
+@click.option("--check", "check_matches", is_flag=True,
+              help="Resolve every title through lucida without downloading.")
 @_service_opts
-def playlist_cmd(url, dry_run, service, country, downscale, out, organize_on, jobs,
+def playlist_cmd(url, dry_run, check_matches, service, country, downscale, out, organize_on, jobs,
                  to_fmt, bitrate, keep_orig, force, hidden):
     """Import a public Apple Music playlist and download its tracks via lucida."""
+    if dry_run and check_matches:
+        raise click.UsageError("Choose either --dry-run or --check, not both.")
     ok = asyncio.run(_playlist(url, dry_run, service, country, downscale, out, hidden,
                                jobs, organize_on, to_fmt=to_fmt, bitrate=bitrate,
-                               keep_orig=keep_orig, force=force))
+                               keep_orig=keep_orig, force=force,
+                               check_matches=check_matches))
+    if not ok:
+        raise click.exceptions.Exit(1)
+
+
+@cli.command("playlist-file")
+@click.argument("file", type=click.Path(exists=True, dir_okay=False))
+@click.option("--name", required=True, help="Playlist name used for its folder and .m3u8.")
+@click.option("--check", "check_matches", is_flag=True,
+              help="Resolve every title through lucida without downloading.")
+@_service_opts
+def playlist_file_cmd(file, name, check_matches, service, country, downscale, out,
+                      organize_on, jobs, to_fmt, bitrate, keep_orig, force, hidden):
+    """Download a corrected text list as an ordered playlist."""
+    items = _read_lines(file)
+    if not items:
+        click.secho(f"Playlist file is empty: {os.path.abspath(file)}", fg="yellow")
+        raise click.exceptions.Exit(1)
+    collection = " ".join(name.split()).strip()
+    if not collection:
+        raise click.UsageError("--name cannot be empty.")
+    if check_matches:
+        ok = asyncio.run(_check_playlist_matches(
+            collection, items, service, country, hidden, jobs,
+            edit_path=os.path.abspath(file)))
+    else:
+        _render_playlist(collection, [
+            {"artist": item.partition(" - ")[0] if " - " in item else "",
+             "title": item.partition(" - ")[2] if " - " in item else item}
+            for item in items
+        ], dry_run=False)
+        ok = asyncio.run(_download_playlist_items(
+            collection, items, os.path.abspath(file), service, country, downscale,
+            out, hidden, jobs, organize_on, to_fmt, bitrate, keep_orig, force))
     if not ok:
         raise click.exceptions.Exit(1)
 
@@ -571,6 +848,8 @@ def config_cmd(music):
     click.echo(f"State/dedup : {paths.STATE_PATH}")
     click.echo(f"Log         : {paths.LOG_PATH}")
     click.echo(f"Failures    : {paths.FAILED_PATH}")
+    click.echo(f"Playlist    : {paths.PLAYLIST_TEXT_PATH}")
+    click.echo(f"Playlist run: {paths.PLAYLIST_RUN_PATH}")
     click.echo(f"Config      : {paths.CONFIG_PATH}")
     if not music:
         click.secho("Tip: `lucida config --music \"D:/Music\"` to change the folder "
@@ -578,6 +857,63 @@ def config_cmd(music):
 
 
 # --- setup / doctor / debug -------------------------------------------------
+
+def _music_health(music_dir: str) -> tuple[bool, str]:
+    """Check that the configured destination can be created and written."""
+    marker = os.path.join(music_dir, f".lucidadl-write-check-{os.getpid()}")
+    try:
+        os.makedirs(music_dir, exist_ok=True)
+        with open(marker, "w", encoding="utf-8") as handle:
+            handle.write("ok")
+        os.remove(marker)
+        return True, "ready"
+    except Exception as exc:
+        try:
+            os.remove(marker)
+        except OSError:
+            pass
+        return False, str(exc)
+
+
+def _stale_partials(music_dir: str, older_than: int = 24 * 3600) -> List[str]:
+    """Find old temporary downloads only in lucidadl's two staging locations."""
+    cutoff = time.time() - older_than
+    out: List[str] = []
+    for folder in (os.path.join(music_dir, ".incoming"),
+                   os.path.join(music_dir, "Music")):
+        try:
+            for name in os.listdir(folder):
+                path = os.path.join(folder, name)
+                if name.endswith(".part") and os.path.isfile(path) and os.path.getmtime(path) < cutoff:
+                    out.append(path)
+        except OSError:
+            continue
+    return out
+
+
+def _cleanup() -> tuple[int, int, int]:
+    state = utils.State(STATE_PATH)
+    removed_paths, removed_items = state.prune()
+    partials = _stale_partials(paths.default_music_dir())
+    removed_partials = 0
+    for path in partials:
+        try:
+            os.remove(path)
+            removed_partials += 1
+        except OSError as exc:
+            click.secho(f"Could not remove {path}: {exc}", fg="yellow")
+    click.secho(
+        f"Cleanup complete — {removed_paths} missing file reference(s), "
+        f"{removed_items} empty item(s), {removed_partials} stale partial file(s) removed.",
+        fg="green",
+    )
+    return removed_paths, removed_items, removed_partials
+
+
+@cli.command("cleanup")
+def cleanup_cmd():
+    """Prune missing download records and partial files older than 24 hours."""
+    _cleanup()
 
 async def _setup() -> bool:
     click.secho("\nlucidadl setup", bold=True)
@@ -619,6 +955,10 @@ async def _doctor(live: bool = False) -> bool:
     ffmpeg_ok = transcode.available()
     cf, ua = load_clearance()
     access_ok = bool(cf and ua)
+    music_ok, music_detail = _music_health(paths.default_music_dir())
+    stale_partials = _stale_partials(paths.default_music_dir())
+    playlist_run = _load_playlist_run()
+    playlist_status = playlist_run.get("status") or "none"
 
     click.secho("\nlucidadl doctor", bold=True)
     click.echo(f"Python      : {sys.version.split()[0]}")
@@ -629,6 +969,12 @@ async def _doctor(live: bool = False) -> bool:
     click.secho(f"Access      : {'saved' if access_ok else 'not prepared'}",
                 fg="green" if access_ok else "yellow")
     click.echo(f"Music       : {paths.default_music_dir()}")
+    click.secho(f"Music write : {music_detail if not music_ok else 'ready'}",
+                fg="green" if music_ok else "red")
+    click.secho(f"Partial files: {len(stale_partials)} stale",
+                fg="yellow" if stale_partials else "green")
+    click.secho(f"Playlist run: {playlist_status}",
+                fg="yellow" if playlist_status in ("running", "incomplete") else "green")
     click.echo(f"App data    : {paths.DATA_DIR}")
 
     live_ok = True
@@ -652,9 +998,13 @@ async def _doctor(live: bool = False) -> bool:
 
     if not browser_ok or not access_ok:
         click.secho("\nNext step: run `lucida setup`.", fg="cyan")
+    if stale_partials:
+        click.secho("Run `lucida cleanup` to remove stale temporary downloads.", fg="cyan")
+    if playlist_status in ("running", "incomplete"):
+        click.secho("Run `lucida retry` to continue the unfinished playlist.", fg="cyan")
     elif not live:
         click.secho("\nEverything needed is present.", fg="green")
-    return browser_ok and ffmpeg_ok and access_ok and live_ok
+    return browser_ok and ffmpeg_ok and access_ok and music_ok and live_ok
 
 
 @cli.command()

--- a/lucidadl/downloader.py
+++ b/lucidadl/downloader.py
@@ -14,6 +14,7 @@ from typing import Dict, List, Optional, Tuple
 
 from . import matching, organize, progress, transcode, utils
 from .api import LucidaClient, LucidaError, FALLBACK_SERVICES, normalize_service, _long
+from .models import FailedItem
 
 
 def _query_variants(line: str) -> List[str]:
@@ -119,6 +120,36 @@ def _filesize_mb(path: Optional[str]) -> float:
         return 0.0
 
 
+def friendly_error(error: Exception) -> str:
+    """Turn low-level failures into a short category plus an actionable next step."""
+    text = str(error).strip() or error.__class__.__name__
+    lowered = text.lower()
+    if "403" in lowered or "cloudflare" in lowered or "clearance" in lowered:
+        return f"access expired or refused — run `lucida setup` ({text})"
+    if "429" in lowered or "rate limit" in lowered or "too many" in lowered:
+        return f"service temporarily rate-limited — retry later ({text})"
+    if "timed out" in lowered or "timeout" in lowered or "stuck" in lowered:
+        return f"service timed out — safe to retry ({text})"
+    if lowered.startswith("write:") or "permission denied" in lowered:
+        return f"could not write the file — check the music folder ({text})"
+    return text
+
+
+def _playlist_download_key(url: str, collection: str, track_no: str) -> str:
+    return f"{url}|playlist|{utils.sanitize(collection)}|{track_no}"
+
+
+def _existing_playlist_copy(state: utils.State, url: str, folder: str,
+                            track_no: str) -> str:
+    """Find a v1.1 URL-keyed file at this exact playlist position, if one exists."""
+    prefix = f"{track_no} - ".casefold()
+    for path in state.done.get(url, []):
+        if (utils._path_exists(path) and utils._is_under(path, folder) and
+                os.path.basename(path).casefold().startswith(prefix)):
+            return path
+    return ""
+
+
 async def _resolve_targets(client, line, kind, service, country, strict, log,
                            quiet=False) -> Optional[List[Dict]]:
     url = await _resolve_url(client, line, service, kind, log, strict, quiet=quiet)
@@ -142,6 +173,36 @@ async def _resolve_targets(client, line, kind, service, country, strict, log,
     return targets
 
 
+async def preview_tracks(client: LucidaClient, items: List[str], service: str,
+                         country: Optional[str], jobs: int = 3,
+                         log=print) -> List[Dict]:
+    """Resolve playlist entries without starting a download, in source order."""
+    sem = asyncio.Semaphore(max(1, jobs))
+
+    async def resolve(line: str, index: int) -> Dict:
+        try:
+            async with sem:
+                targets = await _resolve_targets(
+                    client, line, "track", service, country, False, log, quiet=True
+                )
+            if not targets:
+                return {"index": index, "query": line, "status": "not found"}
+            target = targets[0]
+            meta = target.get("meta") or {}
+            return {
+                "index": index, "query": line, "status": "matched",
+                "url": target.get("url") or "", "artist": meta.get("artist") or "",
+                "title": meta.get("title") or target.get("label") or "",
+            }
+        except Exception as exc:
+            return {"index": index, "query": line, "status": "error",
+                    "error": friendly_error(exc)}
+
+    rows = await asyncio.gather(*(resolve(line, index)
+                                  for index, line in enumerate(items, 1)))
+    return sorted(rows, key=lambda row: row["index"])
+
+
 async def _download_target(client, state, target, country, out, dedup, organize_on,
                            tx, reporter, totals, failed, lock, collection=None) -> None:
     url, label = target["url"], target["label"]
@@ -150,14 +211,24 @@ async def _download_target(client, state, target, country, out, dedup, organize_
     # Artists/ (or another playlist) is still fetched into THIS playlist if it's missing.
     under = (os.path.join(out, organize.PLAYLISTS_DIR, utils.sanitize(collection))
              if collection else None)
+    state_key = url
+    task_key = url
+    if collection and target.get("track_no"):
+        state_key = _playlist_download_key(url, collection, target["track_no"])
+        task_key = state_key
+        # Seed the new occurrence-aware state from an existing 1.1 playlist copy. This
+        # migrates lazily and still lets a duplicate URL at another position download.
+        legacy_path = _existing_playlist_copy(state, url, under, target["track_no"])
+        if dedup and not state.has(state_key, under) and legacy_path:
+            state.add(state_key, legacy_path)
     reserved = False
-    if dedup and not state.reserve(url, under):
+    if dedup and not state.reserve(state_key, under):
         log(f"  ⏭ already downloaded / in progress, skipped: {label}")
         async with lock:
             totals["skip"] += 1
         return
     reserved = dedup
-    reporter.start(url, label)
+    reporter.start(task_key, label)
     track = {"url": url, "csrf": target["csrf"], "csrfFallback": target.get("csrfFallback")}
     path, last_err = None, None
     for attempt in range(2):
@@ -166,21 +237,24 @@ async def _download_target(client, state, target, country, out, dedup, organize_
             path = await client.run_job(
                 handoff, server, _dest_dir(out, organize_on), utils.sanitize(label),
                 title=label,
-                on_status=lambda m, k=url: reporter.status(k, m),
-                on_bytes=lambda d, t, k=url: reporter.progress(k, d, t))
+                on_status=lambda m, k=task_key: reporter.status(k, m),
+                on_bytes=lambda d, t, k=task_key: reporter.progress(k, d, t))
             break
         except Exception as e:
             last_err = e
             if attempt == 0:
-                reporter.status(url, f"{e} — retrying")
+                reporter.status(task_key, f"{friendly_error(e)} — retrying")
                 await asyncio.sleep(3)
     if path is None:
         if reserved:
-            state.release(url)
-        reporter.finish(url, False, f"  ✗ {label}: {last_err}")
+            state.release(state_key)
+        reporter.finish(task_key, False, f"  ✗ {label}: {friendly_error(last_err)}")
         async with lock:
             totals["fail"] += 1
-            failed.append(("track", url))  # retry can download this resolved track directly
+            failed.append(FailedItem(
+                "track", target.get("source_line") if collection else url,
+                collection or "", target.get("track_no") if collection else "",
+            ))
         return
 
     finals = [path]
@@ -200,11 +274,15 @@ async def _download_target(client, state, target, country, out, dedup, organize_
             # report a bogus success or record a non-existent path in the dedup state
             # (that would loop forever): fail it so `retry` re-attempts.
             if reserved:
-                state.release(url)
-            reporter.finish(url, False, f"  ✗ {label}: organized with no file (empty archive?)")
+                state.release(state_key)
+            reporter.finish(task_key, False,
+                            f"  ✗ {label}: organized with no file (empty archive?)")
             async with lock:
                 totals["fail"] += 1
-                failed.append(("track", url))
+                failed.append(FailedItem(
+                    "track", target.get("source_line") if collection else url,
+                    collection or "", target.get("track_no") if collection else "",
+                ))
             return
     if tx and tx.get("fmt"):
         converted = []
@@ -221,24 +299,28 @@ async def _download_target(client, state, target, country, out, dedup, organize_
         finals = converted
         if transcode_error is not None:
             if reserved:
-                state.release(url)
+                state.release(state_key)
             reporter.finish(
-                url, False,
+                task_key, False,
                 f"  ✗ {label}: downloaded, but {tx['fmt']} conversion failed "
                 f"(original kept): {transcode_error}",
             )
             async with lock:
                 totals["fail"] += 1
-                failed.append(("track", url))
+                failed.append(FailedItem(
+                    "track", target.get("source_line") if collection else url,
+                    collection or "", target.get("track_no") if collection else "",
+                ))
             return
 
     async with lock:
         totals["ok"] += 1
     shown = os.path.relpath(finals[0], out) if finals else os.path.basename(path)
     extra = f" (+{len(finals) - 1})" if len(finals) > 1 else ""
-    reporter.finish(url, True, f"  ✓ {shown}{extra}  ({_filesize_mb(finals[0]):.1f} MB)")
+    reporter.finish(task_key, True,
+                    f"  ✓ {shown}{extra}  ({_filesize_mb(finals[0]):.1f} MB)")
     try:
-        state.add(url, finals[0] if finals else path)
+        state.add(state_key, finals[0] if finals else path)
     except Exception as e:
         log(f"  ⚠ state not saved ({url}): {e}")
 
@@ -248,15 +330,16 @@ async def run_batch(client: LucidaClient, state: utils.State, items: List[str],
                     jobs: int, dedup: bool, organize_on: bool = True,
                     tx: Optional[Dict] = None, strict: bool = False,
                     collection: Optional[str] = None, reporter=None,
-                    quiet_resolve: bool = False
-                    ) -> Tuple[Dict[str, int], List[Tuple[str, str]]]:
+                    quiet_resolve: bool = False,
+                    track_numbers: Optional[List[str]] = None
+                    ) -> Tuple[Dict[str, int], List[FailedItem]]:
     if reporter is None:
         reporter = progress.TextReporter(print)
     log = reporter.log
     totals = {"ok": 0, "skip": 0, "fail": 0}
     # (kind, query-or-URL): resolution failures keep their original kind; failures
     # after an album was expanded are direct track URLs and can be retried as tracks.
-    failed: List[Tuple[str, str]] = []
+    failed: List[FailedItem] = []
     sem = asyncio.Semaphore(max(1, jobs))
     lock = asyncio.Lock()
 
@@ -265,24 +348,29 @@ async def run_batch(client: LucidaClient, state: utils.State, items: List[str],
     pad = max(2, len(str(len(items))))  # zero-pad width for playlist track numbers
 
     async def resolve_worker(line: str, idx: int) -> None:
+        track_no = (str(track_numbers[idx]) if track_numbers and idx < len(track_numbers)
+                    else f"{idx + 1:0{pad}d}")
         async with sem:
             try:
                 tg = await _resolve_targets(client, line, kind, service, country, strict,
                                             log, quiet=quiet_resolve)
             except Exception as e:
-                log(f"  ✗ resolving \"{line}\": {e}")
+                log(f"  ✗ resolving \"{line}\": {friendly_error(e)}")
                 async with lock:
                     totals["fail"] += 1
-                    failed.append((kind, line))
+                    failed.append(FailedItem(kind, line, collection or "",
+                                             track_no if collection else ""))
                 return
             if tg is None:
                 log(f"  ✗ not found: {line}")
                 async with lock:
                     totals["fail"] += 1
-                    failed.append((kind, line))  # so `retry` searches the right kind
+                    failed.append(FailedItem(kind, line, collection or "",
+                                             track_no if collection else ""))
                 return
             for t in tg:  # keep the source order (used to number playlist tracks)
-                t["track_no"] = f"{idx + 1:0{pad}d}"
+                t["track_no"] = track_no
+                t["source_line"] = line
             async with lock:
                 targets.extend(tg)
 
@@ -300,10 +388,15 @@ async def run_batch(client: LucidaClient, state: utils.State, items: List[str],
                                        organize_on, tx, reporter, totals, failed, lock,
                                        collection)
             except Exception as e:
-                log(f"  ✗ {target.get('label')}: {e}")
+                log(f"  ✗ {target.get('label')}: {friendly_error(e)}")
                 async with lock:
                     totals["fail"] += 1
-                    failed.append(("track", target.get("url") or target.get("label")))
+                    failed.append(FailedItem(
+                        "track",
+                        target.get("source_line") if collection else
+                        (target.get("url") or target.get("label")),
+                        collection or "", target.get("track_no") if collection else "",
+                    ))
 
     await asyncio.gather(*(dl_worker(t) for t in targets), return_exceptions=True)
 

--- a/lucidadl/models.py
+++ b/lucidadl/models.py
@@ -1,0 +1,19 @@
+"""Tiny shared data contracts used across the CLI and download core."""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+
+class FailedItem(NamedTuple):
+    """Retryable work, with optional playlist placement context.
+
+    The first two fields retain the historical ``(kind, item)`` shape. New playlist
+    failures also carry their collection and original track number so a retry does not
+    fall back into Artists/ or renumber a partial playlist from 01.
+    """
+
+    kind: str
+    item: str
+    collection: str = ""
+    track_no: str = ""

--- a/lucidadl/organize.py
+++ b/lucidadl/organize.py
@@ -129,6 +129,11 @@ def _m3u_title(filename: str) -> str:
     return ((m.group(1) if m else stem).strip()) or stem
 
 
+def _playlist_sort_key(filename: str) -> tuple:
+    match = re.match(r"^(\d+)\s*-", filename)
+    return (int(match.group(1)) if match else 10**12, filename.casefold())
+
+
 def write_m3u8(folder: str) -> Optional[str]:
     """Write/refresh '<folder name>.m3u8' inside `folder`, listing every audio file it
     holds in filename order — playlist tracks are zero-padded 'NN - …', so that order IS
@@ -142,8 +147,11 @@ def write_m3u8(folder: str) -> Optional[str]:
     if not os.path.isdir(_long(folder)):
         return None
     name = os.path.basename(os.path.normpath(folder))
-    tracks = sorted(fn for fn in os.listdir(_long(folder))
-                    if os.path.splitext(fn)[1].lower() in AUDIO_EXT)
+    tracks = sorted(
+        (fn for fn in os.listdir(_long(folder))
+         if os.path.splitext(fn)[1].lower() in AUDIO_EXT),
+        key=_playlist_sort_key,
+    )
     if not tracks:
         return None
     lines = ["#EXTM3U"]
@@ -151,8 +159,16 @@ def write_m3u8(folder: str) -> Optional[str]:
         lines.append(f"#EXTINF:-1,{_m3u_title(fn)}")
         lines.append(fn)
     m3u = os.path.join(folder, utils.sanitize_filename(name + ".m3u8"))
-    with open(_long(m3u), "w", encoding="utf-8", newline="\r\n") as f:
-        f.write("\n".join(lines) + "\n")
+    tmp = m3u + f".{os.getpid()}.tmp"
+    try:
+        with open(_long(tmp), "w", encoding="utf-8", newline="\r\n") as f:
+            f.write("\n".join(lines) + "\n")
+        os.replace(_long(tmp), _long(m3u))
+    finally:
+        try:
+            os.remove(_long(tmp))
+        except OSError:
+            pass
     return m3u
 
 

--- a/lucidadl/paths.py
+++ b/lucidadl/paths.py
@@ -45,6 +45,8 @@ STATE_PATH = str(DATA_DIR / "state.json")          # dedup (downloaded track URL
 CONFIG_PATH = str(DATA_DIR / "config.json")        # user settings (music dir, …)
 LOG_PATH = str(DATA_DIR / "run.log")               # last run's log (fixed, not cwd)
 FAILED_PATH = str(DATA_DIR / "failed.txt")         # last run's failures (for `retry`)
+PLAYLIST_RUN_PATH = str(DATA_DIR / "playlist-run.json")  # resumable last playlist run
+PLAYLIST_TEXT_PATH = str(DATA_DIR / "playlist.txt")      # last extracted track list
 
 
 # --- user config (persisted) ------------------------------------------------

--- a/lucidadl/tui.py
+++ b/lucidadl/tui.py
@@ -13,6 +13,7 @@ import os
 import sys
 
 from . import paths, transcode
+from .session import load_clearance
 
 _TO_NONE = "(none — keep the source format)"
 _SERVICES = ["qobuz", "amazon"]
@@ -31,6 +32,11 @@ def _onoff(b: bool) -> str:
 
 def _is_first_run() -> bool:
     return not (os.path.exists(paths.CONFIG_PATH) or os.path.exists(paths.CLEARANCE_PATH))
+
+
+def _access_ready() -> bool:
+    cf, user_agent = load_clearance()
+    return bool(cf and user_agent)
 
 
 # --- persisted settings -----------------------------------------------------
@@ -138,7 +144,7 @@ def run() -> None:
 
     while True:
         s = _settings()
-        access_saved = os.path.exists(paths.CLEARANCE_PATH)
+        access_saved = _access_ready()
         access = "[green]prepared[/]" if access_saved else "[yellow]setup needed[/]"
         console.print(Panel(
             f"[bold]{_opts_line(s)}[/]\n"
@@ -159,11 +165,15 @@ def run() -> None:
             menu.append(Choice("✨  Set up lucidadl (recommended)", "onboarding"))
         menu += [
             Choice("⬇   Download music", "download"),
-            Choice("🎶  Import an Apple Music playlist", "playlist"),
+            Choice("🎶  Playlists — Apple Music or an edited list", "playlist"),
             Choice("📄  Download from a .txt file", "batch"),
         ]
         failed = cli._read_failed()
-        if failed:
+        pending_playlist = cli._pending_playlist_run()
+        if pending_playlist:
+            menu.append(Choice(
+                f"🔁  Resume {pending_playlist.get('collection', 'playlist')}", "retry"))
+        elif failed:
             menu.append(Choice(f"🔁  Retry failures ({len(failed)})", "retry"))
         menu += [
             Choice("⚙   Settings", "settings"),
@@ -197,7 +207,7 @@ def _dispatch(action, s, console, cli, questionary) -> bool:
     out = paths.default_music_dir()
 
     def _warn_browser():
-        if not os.path.exists(paths.CLEARANCE_PATH):
+        if not _access_ready():
             console.print("[dim]A browser may open briefly to get past "
                           "Cloudflare — that's normal.[/]")
 
@@ -235,23 +245,75 @@ def _dispatch(action, s, console, cli, questionary) -> bool:
         return True
 
     if action == "playlist":
-        url = _ask_text(questionary, "Apple Music playlist URL:", "(empty = back)")
-        if not url:
+        from questionary import Choice
+        source = questionary.select("Playlist source:", choices=[
+            Choice("🍎  Public Apple Music link", "apple"),
+            Choice("📄  Edited .txt list", "file"),
+            Choice("← Back", "back"),
+        ]).ask()
+        if source in (None, "back"):
             return False
-        dry = questionary.confirm("Just list (without downloading)?", default=False).ask()
-        if dry is None:  # cancel must NOT fall through to a full download
+        if source == "apple":
+            url = _ask_text(questionary, "Apple Music playlist URL:", "(empty = back)")
+            if not url:
+                return False
+        else:
+            raw_path = _ask_text(
+                questionary, "Playlist text file:", "(one artist - title per line; empty = back)",
+                default=cli.PLAYLIST_TEXT_PATH,
+            )
+            if not raw_path:
+                return False
+            file_path = os.path.abspath(os.path.expandvars(os.path.expanduser(
+                raw_path.strip('"'))))
+            if not os.path.isfile(file_path):
+                console.print(f"[red]File not found: {file_path}[/]")
+                return True
+            items = cli._read_lines(file_path)
+            if not items:
+                console.print("[yellow]The playlist file is empty.[/]")
+                return True
+            name = _ask_text(questionary, "Playlist name:", "(empty = back)")
+            if not name:
+                return False
+        mode = questionary.select("What should lucidadl do?", choices=[
+            Choice("⬇   Download or resume this playlist", "download"),
+            Choice("✓   Check every automatic match first", "check"),
+            *([Choice("📄  Only extract and save the track list", "list")]
+              if source == "apple" else []),
+            Choice("← Back", "back"),
+        ]).ask()
+        if mode in (None, "back"):
             return False
-        _warn_browser()
-        asyncio.run(cli._playlist(url, dry, s["service"], None, "original", out,
-                                  hidden=False, jobs=s["jobs"], organize_on=True,
-                                  to_fmt=s["to"], bitrate=s["bitrate"],
-                                  keep_orig=s["keep_orig"], force=s["force"]))
+        if not (source == "apple" and mode == "list"):
+            _warn_browser()
+        if source == "apple":
+            asyncio.run(cli._playlist(
+                url, mode == "list", s["service"], None, "original", out,
+                hidden=False, jobs=s["jobs"], organize_on=True, to_fmt=s["to"],
+                bitrate=s["bitrate"], keep_orig=s["keep_orig"], force=s["force"],
+                check_matches=mode == "check"))
+        elif mode == "check":
+            asyncio.run(cli._check_playlist_matches(
+                name, items, s["service"], None, hidden=False, jobs=s["jobs"],
+                edit_path=file_path))
+        else:
+            asyncio.run(cli._download_playlist_items(
+                name, items, file_path, s["service"], None, "original", out,
+                hidden=False, jobs=s["jobs"], organize_on=True, to_fmt=s["to"],
+                bitrate=s["bitrate"], keep_orig=s["keep_orig"], force=s["force"]))
         return True
 
     if action == "batch":
         return _batch_action(console, cli, questionary, go)
 
     if action == "retry":
+        pending = cli._pending_playlist_run()
+        if pending:
+            _warn_browser()
+            result = asyncio.run(cli._resume_playlist_run(pending))
+            _show_run_summary(result, cli._playlist_run_options(pending)["out"], console)
+            return True
         items = cli._read_failed()
         if not items:
             console.print("[yellow]No failures to retry.[/]")
@@ -327,6 +389,7 @@ def _tools_action(console, cli, questionary) -> bool:
         Choice("🛡   Prepare or refresh access", "setup"),
         Choice("🩺  Check the installation", "doctor"),
         Choice("🌐  Test browser + lucida.to", "doctor-live"),
+        Choice("🧹  Clean stale state and temporary files", "cleanup"),
         Choice("📂  Open the music folder", "openfolder"),
         Choice("📄  Open the last run log", "log"),
         Choice("← Back", "back"),
@@ -337,6 +400,15 @@ def _tools_action(console, cli, questionary) -> bool:
         return bool(asyncio.run(cli._setup()))
     if action in ("doctor", "doctor-live"):
         asyncio.run(cli._doctor(live=action == "doctor-live"))
+        return True
+    if action == "cleanup":
+        confirmed = questionary.confirm(
+            "Remove missing state entries and .part files older than 24 hours?",
+            default=True,
+        ).ask()
+        if not confirmed:
+            return False
+        cli._cleanup()
         return True
     if action == "openfolder":
         _open_path(paths.default_music_dir(), console)

--- a/lucidadl/utils.py
+++ b/lucidadl/utils.py
@@ -143,3 +143,34 @@ class State:
             with open(tmp, "w", encoding="utf-8") as f:
                 json.dump({"done": self.done}, f, ensure_ascii=False, indent=2)
             os.replace(tmp, self.path)
+
+    def prune(self) -> tuple[int, int]:
+        """Forget recorded file paths that no longer exist.
+
+        URL-only legacy entries are retained because their location cannot be checked.
+        Returns ``(removed_paths, removed_items)``.
+        """
+        removed_paths = 0
+        removed_items = 0
+        changed = False
+        with self._lock:
+            for key in list(self.done):
+                old = self.done[key]
+                if not old:  # oldest state format: keep its conservative dedup behaviour
+                    continue
+                live = [path for path in old if _path_exists(path)]
+                removed_paths += len(old) - len(live)
+                if live:
+                    if live != old:
+                        self.done[key] = live
+                        changed = True
+                else:
+                    del self.done[key]
+                    removed_items += 1
+                    changed = True
+            if changed:
+                tmp = self.path + f".{os.getpid()}.tmp"
+                with open(tmp, "w", encoding="utf-8") as f:
+                    json.dump({"done": self.done}, f, ensure_ascii=False, indent=2)
+                os.replace(tmp, self.path)
+        return removed_paths, removed_items

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lucidadl"
-version = "1.1.0"
-description = "Fast, parallel CLI music downloader for lucida.to (Qobuz, Amazon Music) with local transcoding and playlist import."
+version = "1.2.0"
+description = "Fast, parallel CLI music downloader for lucida.to with resilient Apple Music playlist imports."
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
 authors = [{ name = "Jude-A" }]
-keywords = ["music", "downloader", "lucida", "qobuz", "amazon", "flac", "cli", "tui"]
+keywords = ["music", "downloader", "lucida", "qobuz", "amazon", "apple-music", "playlist", "flac", "cli", "tui"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",

--- a/selftest.py
+++ b/selftest.py
@@ -1,9 +1,13 @@
 """Offline self-test of the pure logic (no browser, no network)."""
 
+import asyncio as _aio
+
 from lucidadl import utils, matching
 from lucidadl.api import (
-    normalize_service, default_country, _long, _apple_tracks_from_obj, DOWNSCALE_CHOICES,
+    LucidaClient, normalize_service, default_country, _long, _apple_tracks_from_obj,
+    _apple_playlist_from_scripts, is_apple_playlist_url, DOWNSCALE_CHOICES,
 )
+from lucidadl.models import FailedItem
 
 fails = []
 
@@ -34,6 +38,10 @@ check("default_country qobuz=US", default_country("qobuz") == "US")
 check("default_country amazon=''", default_country("amazon") == "")
 check("default_country other=US", default_country("tidal") == "US")
 check("formats", DOWNSCALE_CHOICES[0] == "original" and "flac" in DOWNSCALE_CHOICES)
+check("Apple URL validation accepts playlists only",
+      is_apple_playlist_url("https://music.apple.com/fr/playlist/mix/pl.123")
+      and not is_apple_playlist_url("https://music.apple.com/fr/album/record/123")
+      and not is_apple_playlist_url("https://example.com/playlist/mix/pl.123"))
 
 # long path (Windows)
 import os as _os
@@ -52,6 +60,28 @@ out = []
 _apple_tracks_from_obj(sample, out)
 check("apple extractor: 2 songs, playlist node skipped",
       len(out) == 2 and out[0] == {"title": "Otherside", "artist": "RHCP"})
+
+_apple_name, _apple_structured = _apple_playlist_from_scripts([
+    "not-json",
+    __import__("json").dumps(sample),
+])
+check("apple structured extractor: playlist name + ordered songs",
+      _apple_name == "My PL" and _apple_structured == [
+          {"title": "Otherside", "artist": "RHCP"},
+          {"title": "Scar Tissue", "artist": "RHCP"},
+      ])
+
+_duplicate_sample = {"data": [{"type": "playlists", "attributes": {"name": "Loop"},
+                     "relationships": {"tracks": {"data": [
+                         {"type": "songs", "attributes": {
+                             "name": "Again", "artistName": "Artist"}},
+                         {"type": "songs", "attributes": {
+                             "name": "Again", "artistName": "Artist"}},
+                     ]}}}]}
+_duplicate_name, _duplicate_tracks = _apple_playlist_from_scripts([
+    __import__("json").dumps(_duplicate_sample)])
+check("apple structured extractor preserves intentional duplicate positions",
+      _duplicate_name == "Loop" and len(_duplicate_tracks) == 2)
 
 # State dedup
 import tempfile
@@ -93,6 +123,12 @@ check("legacy unscoped = done", s3.has("urlLegacy"))
 check("legacy scoped = re-download", not s3.has("urlLegacy", under=_pls))
 _os.remove(_pf)
 check("deleted playlist copy -> not done for that playlist", not s3.has("urlE", under=_pls))
+s3.done["gone"] = [_os.path.join(_d3, "missing.flac")]
+_removed_paths, _removed_items = s3.prune()
+check("state prune removes missing paths/items",
+      _removed_paths == 2 and _removed_items == 1 and "gone" not in s3.done
+      and s3.done.get("urlE") == [_af])
+check("state prune preserves unverifiable legacy entries", "urlLegacy" in s3.done)
 _sh0.rmtree(_d3, ignore_errors=True)
 
 # organize: album_dir + zip extraction/placement (no real tags -> Unknown)
@@ -213,6 +249,10 @@ check("m3u8: empty folder -> None (no file written)",
 check("_m3u_title strips 'NN - ' prefix and extension",
       _org._m3u_title("07 - Enfant Perdu.m4a") == "Enfant Perdu"
       and _org._m3u_title("No Prefix.flac") == "No Prefix")
+check("m3u8 numeric ordering survives mixed zero-padding",
+      sorted(["100 - Last.flac", "02 - Second.flac", "005 - Fifth.flac"],
+             key=_org._playlist_sort_key) ==
+      ["02 - Second.flac", "005 - Fifth.flac", "100 - Last.flac"])
 _sh.rmtree(_d5, ignore_errors=True)
 
 # downloader meta builders
@@ -303,6 +343,50 @@ check("variants: title-only + primary-artist forms",
       "PUKE SOMETHING" in _v2 and "Ptite Soeur PUKE SOMETHING" in _v2)
 check("variants: no separator -> just the line", _qv("Madonna") == ["Madonna"])
 
+from lucidadl.downloader import friendly_error as _friendly_error
+check("friendly error: access guidance", "lucida setup" in _friendly_error(Exception("HTTP 403")))
+check("friendly error: timeout retry guidance", "safe to retry" in _friendly_error(Exception("timed out")))
+
+from lucidadl.downloader import _playlist_download_key, _existing_playlist_copy
+_legacy_playlist_dir = tempfile.mkdtemp(prefix="lucidadl_playlist_state_")
+_legacy_file = _os.path.join(_legacy_playlist_dir, "02 - Song.flac")
+with open(_legacy_file, "wb") as _handle:
+    _handle.write(b"x")
+_legacy_state = utils.State(_os.path.join(_legacy_playlist_dir, "state.json"))
+_legacy_state.add("track-url", _legacy_file)
+check("playlist state: each duplicate position gets a distinct key",
+      _playlist_download_key("track-url", "Mix", "02") !=
+      _playlist_download_key("track-url", "Mix", "07"))
+check("playlist state: v1.1 copy recognized only at its original position",
+      _existing_playlist_copy(_legacy_state, "track-url", _legacy_playlist_dir, "02") ==
+      _legacy_file and
+      not _existing_playlist_copy(_legacy_state, "track-url", _legacy_playlist_dir, "07"))
+_sh0.rmtree(_legacy_playlist_dir, ignore_errors=True)
+
+from lucidadl.downloader import preview_tracks as _preview_tracks
+class _PreviewClient:
+    async def search(self, query, _service):
+        if "Missing" in query:
+            return {"tracks": []}
+        title = query.split(" - ", 1)[-1]
+        return {"tracks": [{"url": "https://qobuz/" + title, "title": title,
+                            "artist": "Artist", "context": title + " Artist"}]}
+
+    async def fetch_page_data(self, url, _country):
+        title = url.rsplit("/", 1)[-1]
+        return {"info": {"type": "track", "url": url, "title": title,
+                         "artists": [{"name": "Artist"}], "producers": ["p"]},
+                "token": "token", "tokenExpiry": 1}
+
+    tracks_from_pd = staticmethod(LucidaClient.tracks_from_pd)
+
+_preview = _aio.run(_preview_tracks(
+    _PreviewClient(), ["Artist - One", "Artist - Missing", "Artist - Two"],
+    "qobuz", "US", jobs=3, log=lambda *_: None))
+check("playlist check: preserves order and reports missing matches",
+      [row["index"] for row in _preview] == [1, 2, 3]
+      and [row["status"] for row in _preview] == ["matched", "not found", "matched"])
+
 _title_hits = [
     {"url": "wrong", "title": "Enfant Perdu", "artist": "Some Other Artist", "context": "Enfant Perdu Some Other Artist"},
     {"url": "right", "title": "Enfant Perdu", "artist": "Sinyo", "context": "Enfant Perdu Sinyo"},
@@ -328,7 +412,7 @@ check("transcode cmd has -b:a 192k",
 
 # fast HTTP path parsing (raw SvelteKit JSON5 blob -> tracks + helpers)
 import pyjson5
-from lucidadl.api import LucidaClient, _between, _filename_from_cd
+from lucidadl.api import _between, _filename_from_cd, _retry_delay
 _alb = ('{info:{success:true,type:"album",title:"Cal",tracks:['
         '{title:"A",url:"https://q/track/1",csrf:"C1",csrfFallback:"F1",producers:["p"]},'
         '{title:"B",url:"https://q/track/2",csrf:"C2",csrfFallback:null,producers:null}'
@@ -345,8 +429,11 @@ check("_between slices blob",
 check("filename from content-disposition",
       _filename_from_cd('attachment; filename="01 - Song.flac"') == "01 - Song.flac")
 
+class _RetryResponse:
+    headers = {"Retry-After": "99"}
+check("network retry delay is bounded", _retry_delay(_RetryResponse(), 0) == 30)
+
 # refresh dedup: N concurrent 403-refreshes must call acquire() exactly once
-import asyncio as _aio
 _calls = {"n": 0}
 async def _fake_acquire():
     _calls["n"] += 1
@@ -372,6 +459,9 @@ from lucidadl import cli as _cli
 with _patch.object(_cli, "chromium_installed", _AsyncMock(return_value=True)), \
      _patch.object(_cli.transcode, "available", return_value=True), \
      _patch.object(_cli, "load_clearance", return_value=("CF", "UA")), \
+     _patch.object(_cli, "_music_health", return_value=(True, "ready")), \
+     _patch.object(_cli, "_stale_partials", return_value=[]), \
+     _patch.object(_cli, "_load_playlist_run", return_value={}), \
      _patch.object(_cli, "lucida_context") as _browser_ctx:
     _doctor_out = _io.StringIO()
     with _ctxlib.redirect_stdout(_doctor_out):
@@ -389,28 +479,66 @@ check("setup: installs a missing browser before preparing access",
 
 with _patch.object(_tui.os.path, "exists", return_value=False):
     check("tui: empty app data is detected as first run", _tui._is_first_run())
+with _patch.object(_tui, "load_clearance", return_value=(None, None)):
+    check("tui: corrupt/empty access is not shown as prepared", not _tui._access_ready())
+with _patch.object(_tui, "load_clearance", return_value=("CF", "UA")):
+    check("tui: complete access is shown as prepared", _tui._access_ready())
 
 # corrupt or hand-edited settings must not prevent the TUI from starting
 with _patch.object(_tui.paths, "load_config", return_value={"jobs": "many"}):
     check("tui: invalid jobs setting falls back safely", _tui._settings()["jobs"] == 3)
 
+# ordinary downloads use the shared runner without depending on playlist-only locals
+class _TuiConsole:
+    def print(self, *_args, **_kwargs):
+        pass
+
+
+class _TuiCli:
+    @staticmethod
+    async def _run(*_args, **_kwargs):
+        return {"ok": 1, "skip": 0, "fail": 0}, []
+
+
+def _invoke_tui_go(_s, _console, _cli_obj, _questionary, go):
+    go(["Artist - Song"], "track", False)
+    return True
+
+
+with _patch.object(_tui, "_download_action", side_effect=_invoke_tui_go), \
+     _patch.object(_tui, "_access_ready", return_value=True), \
+     _patch.object(_tui, "_show_run_summary"):
+    _tui_download_ok = _tui._dispatch(
+        "download",
+        {"service": "qobuz", "jobs": 1, "to": None, "bitrate": None,
+         "keep_orig": False, "force": False},
+        _TuiConsole(), _TuiCli(), object(),
+    )
+check("tui: ordinary downloads do not depend on playlist choices", _tui_download_ok)
+
 # failures preserve album/track intent, while old files stay backwards-compatible
 _failed_dir = tempfile.mkdtemp(prefix="lucidadl_failed_")
 _failed_path = _os.path.join(_failed_dir, "failed.txt")
-with _patch.object(_cli, "FAILED_PATH", _failed_path):
+_playlist_run_path = _os.path.join(_failed_dir, "playlist-run.json")
+with _patch.object(_cli, "FAILED_PATH", _failed_path), \
+     _patch.object(_cli, "PLAYLIST_RUN_PATH", _playlist_run_path):
     _cli._write_failed([("album", "Artist - Album"), ("track", "Artist - Song")])
     check("retry: typed failures round-trip", _cli._read_failed() == [
-        ("album", "Artist - Album"), ("track", "Artist - Song")])
+        FailedItem("album", "Artist - Album"), FailedItem("track", "Artist - Song")])
+    _cli._write_failed([
+        FailedItem("track", "Artist - Playlist Song", "My Mix", "07")])
+    check("retry: playlist context round-trips", _cli._read_failed() == [
+        FailedItem("track", "Artist - Playlist Song", "My Mix", "07")])
     with open(_failed_path, "w", encoding="utf-8") as _legacy:
         _legacy.write("Legacy Artist - Song\n")
     check("retry: legacy failures remain track retries",
-          _cli._read_failed() == [("track", "Legacy Artist - Song")])
+          _cli._read_failed() == [FailedItem("track", "Legacy Artist - Song")])
 
     _retry_calls = []
     async def _fake_retry_run(values, kind, *args, **kwargs):
         _retry_calls.append((kind, values))
         if kind == "track":
-            return ({"ok": 0, "skip": 0, "fail": 1}, [("track", values[0])])
+            return ({"ok": 0, "skip": 0, "fail": 1}, [FailedItem("track", values[0])])
         return ({"ok": 1, "skip": 0, "fail": 0}, [])
 
     with _patch.object(_cli, "_run", side_effect=_fake_retry_run):
@@ -420,10 +548,49 @@ with _patch.object(_cli, "FAILED_PATH", _failed_path):
                 "qobuz", None, "original", _failed_dir, False, 3))
     check("retry: albums and tracks are dispatched with their original type",
           _retry_calls == [
-              ("track", ["Artist - Song"]), ("album", ["Artist - Album"])])
+              ("album", ["Artist - Album"]), ("track", ["Artist - Song"])])
     check("retry: only unresolved items remain",
-          _retry_result[1] == [("track", "Artist - Song")]
-          and _cli._read_failed() == [("track", "Artist - Song")])
+          _retry_result[1] == [FailedItem("track", "Artist - Song")]
+          and _cli._read_failed() == [FailedItem("track", "Artist - Song")])
+
+    _playlist_retry = []
+    async def _fake_playlist_retry(values, kind, *args, **kwargs):
+        _playlist_retry.append((values, kind, kwargs))
+        return ({"ok": 1, "skip": 0, "fail": 0}, [])
+
+    with _patch.object(_cli, "_run", side_effect=_fake_playlist_retry):
+        with _ctxlib.redirect_stdout(_io.StringIO()):
+            _aio.run(_cli._retry(
+                [FailedItem("track", "Artist - Song", "My Mix", "07")],
+                "qobuz", None, "original", _failed_dir, False, 3))
+    check("retry: playlist stays in its collection with original number",
+          len(_playlist_retry) == 1
+          and _playlist_retry[0][2].get("collection") == "My Mix"
+          and _playlist_retry[0][2].get("track_numbers") == ["07"])
+
+    _interrupted = {
+        "status": "running", "collection": "Interrupted Mix",
+        "tracks": [
+            {"track_no": "01", "query": "Artist - One"},
+            {"track_no": "02", "query": "Artist - Two"},
+        ],
+        "options": {"service": "amazon", "out": _failed_dir, "jobs": 5},
+    }
+    _cli._save_playlist_run(_interrupted)
+    _resume_calls = []
+    async def _fake_resume(values, kind, *args, **kwargs):
+        _resume_calls.append((values, kind, args, kwargs))
+        return ({"ok": 1, "skip": 1, "fail": 0}, [])
+    with _patch.object(_cli, "_run", side_effect=_fake_resume):
+        with _ctxlib.redirect_stdout(_io.StringIO()):
+            _aio.run(_cli._resume_playlist_run(_cli._pending_playlist_run()))
+    check("playlist recovery: interrupted run resumes full ordered list",
+          len(_resume_calls) == 1
+          and _resume_calls[0][0] == ["Artist - One", "Artist - Two"]
+          and _resume_calls[0][3].get("track_numbers") == ["01", "02"]
+          and _resume_calls[0][3].get("collection") == "Interrupted Mix")
+    check("playlist recovery: successful resume marked complete",
+          _cli._load_playlist_run().get("status") == "complete")
 _sh0.rmtree(_failed_dir)
 
 # unsupported playlist URLs fail immediately without launching Playwright
@@ -434,6 +601,14 @@ with _patch.object(_cli, "lucida_context") as _playlist_browser:
             tempfile.gettempdir(), False, 3))
 check("playlist: unsupported links fail before opening a browser",
       not _unsupported_ok and not _playlist_browser.called)
+
+check("playlist: failures before download retain recovery context",
+      _cli._failed_result(
+          ["Artist - One", "Artist - Two"], "track", "My Mix", ["01", "02"]
+      )[1] == [
+          FailedItem("track", "Artist - One", "My Mix", "01"),
+          FailedItem("track", "Artist - Two", "My Mix", "02"),
+      ])
 
 # command contracts used by scripts: missing input/search failure must be non-zero,
 # while an explicit search cancellation remains a normal successful exit
@@ -455,6 +630,9 @@ check("search: explicit cancellation returns exit 0", _search_cancelled.exit_cod
 
 _help = _runner.invoke(_cli.cli, ["--help"])
 check("cli: developer debug command is hidden", "  debug " not in _help.output)
+_version = _runner.invoke(_cli.cli, ["--version"])
+check("cli: source version matches release metadata",
+      _version.exit_code == 0 and "1.2.0" in _version.output)
 
 print()
 if fails:


### PR DESCRIPTION
## What changed

- make Apple Music extraction more resilient and keep duplicate playlist positions
- add pre-download match checking and reviewed text-list playlist downloads
- preserve playlist context and track numbers across interruptions and retries
- add bounded network retries, incomplete-download protection, cleanup, and richer diagnostics
- simplify the playlist paths in the interactive menu and refresh the README for 1.2.0

## Validation

- offline self-test suite
- source compilation and diff checks
- package build and metadata validation
- clean wheel install and CLI smoke test
- public Apple Music playlist extraction and lucida match preview
