### PR TITLE
Add Spotify and Deezer playlist imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-09-03
+
+### Added
+- Public Spotify playlists can now use the complete `playlist`, `--dry-run`, `--check`,
+  correction, download, and resume workflow without a Spotify login or API key.
+- Public Deezer playlists use the same workflow, including pagination for large lists.
+
+### Changed
+- Playlist source detection is automatic from the pasted URL. The CLI and TUI now offer
+  one streaming-playlist entry point for Apple Music, Spotify, and Deezer.
+- Spotify imports detect the public player's 100-item window and refuse a known partial
+  import, directing the user to `playlist-file` instead of silently losing tracks.
+- Spotify podcast episodes are ignored because lucidadl's matching and download flow is
+  intentionally music-only.
+- Automatic matching now rejects clearly labelled alternate versions and cover results
+  where the requested performer is only a secondary credit.
+
 ## [1.2.0] - 2026-09-03
 
 ### Added
@@ -122,7 +139,8 @@ First public release.
 - **Fixed, configurable download directory** (`~/Downloads/music` by default;
   `lucida config --music`, or the `LUCIDADL_MUSIC` env var).
 
-[Unreleased]: https://github.com/Jude-A/lucidadl/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/Jude-A/lucidadl/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/Jude-A/lucidadl/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/Jude-A/lucidadl/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/Jude-A/lucidadl/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/Jude-A/lucidadl/compare/v0.1.1...v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,8 +32,8 @@ python selftest.py        # prints "ALL OFFLINE TESTS PASSED"
 CI runs the same self-tests on Linux and Windows for Python 3.10–3.12, plus a packaging
 check (`python -m build` + `twine check`).
 
-For playlist changes, also run a public Apple Music `--dry-run`; use `--check` when the
-matching path changed. Neither command writes audio files.
+For playlist changes, also run `--dry-run` with the affected public source; use `--check`
+when the matching path changed. Neither command writes audio files.
 
 ### What can't be tested automatically
 

--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@ commands and an interactive terminal interface.
 
 lucidadl downloads tracks and albums in parallel, organizes them from their metadata,
 can convert them locally with ffmpeg, accepts large `.txt` batches, and imports public
-Apple Music playlists with match checking and reliable resume. It intentionally remains
-a lightweight personal tool rather than a music-library or streaming-account platform.
+Apple Music, Spotify, and Deezer playlists with match checking and reliable resume. It
+intentionally remains a lightweight personal tool rather than a music-library or
+streaming-account platform.
 
 > Use lucidadl only for content you are entitled to download. You are responsible for
 > complying with applicable law and with the terms of the services involved. This
-> project is not affiliated with lucida.to, Apple, Qobuz, Amazon, or any streaming
-> service.
+> project is not affiliated with lucida.to, Apple, Spotify, Deezer, Qobuz, Amazon,
+> or any streaming service.
 
 ## Highlights
 
@@ -26,8 +27,8 @@ a lightweight personal tool rather than a music-library or streaming-account pla
 - FLAC source downloads and optional local MP3, AAC, Opus, Ogg, WAV, or FLAC conversion.
 - Tag-based organization under `Artists/<Artist>/<Album>/`.
 - Batch downloads from any `.txt` file, without modifying the source list.
-- Public Apple Music playlist import with match checking, resume, ordered tracks, and a
-  portable `.m3u8` file.
+- Public Apple Music, Spotify, and Deezer playlist imports with match checking, resume,
+  ordered tracks, and a portable `.m3u8` file.
 - Existence-aware deduplication, safe matching, and one-command retry for failures.
 - Guided first-run setup, diagnostics, progress bars, and a compact interactive menu.
 
@@ -94,15 +95,18 @@ The source file is never edited. Already downloaded items are skipped unless `--
 is used. When `--file` is omitted, the plural commands use `./inputs/tracks.txt` or
 `./inputs/albums.txt`; ready-to-copy examples are included in the repository.
 
-### 3. A public Apple Music playlist
+### 3. A public streaming playlist
 
 ```bash
 lucida playlist "https://music.apple.com/.../pl.xxxxxxxx"
+lucida playlist "https://open.spotify.com/playlist/xxxxxxxx"
+lucida playlist "https://www.deezer.com/playlist/xxxxxxxx"
 ```
 
-lucidadl reads the public Apple Music page, resolves each track through lucida.to, and
-stores the result under `Playlists/<playlist name>/`. An `.m3u8` file is written beside
-the tracks so players and devices recognize the folder as an actual playlist.
+lucidadl detects the service from the URL, reads its public track list, resolves each
+title through lucida.to, and stores the result under `Playlists/<playlist name>/`. An
+`.m3u8` file is written beside the tracks so players and devices recognize the folder as
+an actual playlist.
 
 Preview the extraction without downloading anything:
 
@@ -128,9 +132,11 @@ If a playlist is interrupted, `lucida retry` resumes it with its original folder
 settings, and track numbers. Existing files are skipped, and the `.m3u8` is rebuilt when
 the run finishes. Repeating the same song at two different positions is supported.
 
-Apple Music remains the only remote playlist source. Cross-service playlist translation
-and account authorization intentionally belong in a separate companion project rather
-than in this downloader.
+Only public playlists are read: lucidadl does not connect to or modify an Apple Music,
+Spotify, or Deezer account. Spotify's public player exposes at most 100 items; when the
+declared playlist is longer, lucidadl stops with an explicit message instead of importing
+an incomplete list. Cross-service playlist translation and account authorization remain
+the responsibility of a separate companion project.
 
 ## Interactive menu
 
@@ -145,7 +151,7 @@ Run `lucida` without arguments (or `lucida ui`):
 
 ► What do you want to do?
   ⬇   Download music
-  🎶  Playlists — Apple Music or an edited list
+  🎶  Playlists — streaming link or an edited list
   📄  Download from a .txt file
   ⚙   Settings
   🧰  Help, access and diagnostics

--- a/lucidadl/__init__.py
+++ b/lucidadl/__init__.py
@@ -1,3 +1,3 @@
 """lucidadl — automated music downloader driving lucida.to through a real browser."""
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"

--- a/lucidadl/api.py
+++ b/lucidadl/api.py
@@ -9,13 +9,14 @@ Flow (all httpx, like the Rust jelni client):
   start_download(track)   -> POST /api/load -> {handoff, server}
   run_job(handoff,server) -> poll <server>.lucida.to (Cloudflare-free) -> stream file
 
-Apple Music playlist scraping (applemusic_tracklist) DOES need a page — it's not a
-lucida service — so it's a module function taking a Playwright page.
+Public Spotify and Deezer playlist metadata is read directly over HTTP. Apple Music
+still needs a Playwright page because its public track list is rendered dynamically.
 """
 
 from __future__ import annotations
 
 import asyncio
+import html as html_lib
 import json
 import os
 import re
@@ -37,6 +38,11 @@ SERVICE_ALIASES = {"amazon_music": "amazon", "yandex_music": "yandex"}
 COUNTRY_DEFAULTS = {"qobuz": "US", "amazon": "", "deezer": "FR"}
 # Services tried (in order) when the primary one finds nothing (unless --strict).
 FALLBACK_SERVICES = ["qobuz", "amazon"]
+PLAYLIST_SOURCE_NAMES = {
+    "apple": "Apple Music",
+    "spotify": "Spotify",
+    "deezer": "Deezer",
+}
 
 # Values of the #convert <select> (also the lucida downscale strings).
 DOWNSCALE_CHOICES = ["original", "flac", "mp3", "ogg-vorbis", "opus", "m4a-aac", "wav"]
@@ -69,12 +75,35 @@ def default_country(service: str) -> str:
     return COUNTRY_DEFAULTS.get(normalize_service(service), "US")
 
 
-def is_apple_playlist_url(url: str) -> bool:
+def playlist_source(url: str) -> str:
+    """Return the supported public-playlist source identified by its canonical URL."""
     parsed = urlparse((url or "").strip())
     host = (parsed.hostname or "").lower()
     parts = [part.lower() for part in parsed.path.split("/") if part]
-    return ((host == "music.apple.com" or host.endswith(".music.apple.com")) and
-            "playlist" in parts)
+    if ((host == "music.apple.com" or host.endswith(".music.apple.com")) and
+            "playlist" in parts):
+        return "apple"
+    if host in ("open.spotify.com", "spotify.com", "www.spotify.com") and "playlist" in parts:
+        return "spotify"
+    if host in ("deezer.com", "www.deezer.com") and "playlist" in parts:
+        return "deezer"
+    return ""
+
+
+def playlist_source_name(source: str) -> str:
+    return PLAYLIST_SOURCE_NAMES.get(source, source or "unknown source")
+
+
+def is_apple_playlist_url(url: str) -> bool:
+    return playlist_source(url) == "apple"
+
+
+def _playlist_id(url: str) -> str:
+    parts = [part for part in urlparse((url or "").strip()).path.split("/") if part]
+    for index, part in enumerate(parts[:-1]):
+        if part.lower() == "playlist":
+            return parts[index + 1]
+    return ""
 
 
 class LucidaClient:
@@ -402,6 +431,153 @@ def _find_results_node(obj: Any, depth: int = 0) -> Optional[Dict[str, Any]]:
             if r:
                 return r
     return None
+
+
+# --- public playlist sources ------------------------------------------------
+
+async def _public_get(url: str):
+    """Fetch a public playlist page/API with the same small retry policy as lucida."""
+    import httpx
+
+    headers = {
+        # Spotify's public SEO response includes the declared playlist size for this
+        # neutral browser UA; a detailed Chrome UA receives only the web-app shell.
+        "User-Agent": "Mozilla/5.0",
+        "Accept-Language": "en-US,en;q=0.8",
+    }
+    async with httpx.AsyncClient(headers=headers, follow_redirects=True, timeout=30.0) as client:
+        for attempt in range(3):
+            try:
+                response = await client.get(url)
+            except Exception:
+                if attempt == 2:
+                    raise
+                await asyncio.sleep(2 ** attempt)
+                continue
+            if response.status_code == 429 or response.status_code in (500, 502, 503, 504):
+                if attempt < 2:
+                    await asyncio.sleep(_retry_delay(response, attempt))
+                    continue
+            response.raise_for_status()
+            return response
+    raise LucidaError("public playlist request failed after retrying")
+
+
+def _spotify_playlist_from_html(raw: str) -> Tuple[str, List[Dict[str, str]]]:
+    """Parse the stable JSON payload shipped with Spotify's public embed player."""
+    match = re.search(
+        r'<script[^>]+id=["\']__NEXT_DATA__["\'][^>]*>(.*?)</script>',
+        raw or "", re.I | re.S,
+    )
+    if not match:
+        raise LucidaError("Spotify's public playlist data was not found (page format changed?)")
+    try:
+        data = json.loads(html_lib.unescape(match.group(1)))
+        entity = data["props"]["pageProps"]["state"]["data"]["entity"]
+    except (KeyError, TypeError, ValueError) as exc:
+        raise LucidaError(f"Spotify playlist data could not be read: {exc}") from exc
+    if not isinstance(entity, dict) or str(entity.get("type") or "").lower() != "playlist":
+        raise LucidaError("Spotify did not return a public playlist")
+    name = " ".join(str(entity.get("name") or entity.get("title") or "").split())
+    tracks: List[Dict[str, str]] = []
+    for item in entity.get("trackList") or []:
+        if not isinstance(item, dict) or item.get("entityType") not in (None, "track"):
+            continue
+        title = " ".join(str(item.get("title") or "").split())
+        artist = " ".join(str(item.get("subtitle") or "").replace("\xa0", " ").split())
+        if title and artist:
+            tracks.append({"title": title, "artist": artist})
+    return name, tracks
+
+
+def _spotify_total_from_html(raw: str) -> Optional[int]:
+    """Read the public page's declared item count, used to detect the embed's 100 cap."""
+    for match in re.finditer(
+            r'<script[^>]+type=["\']application/ld\+json["\'][^>]*>(.*?)</script>',
+            raw or "", re.I | re.S):
+        try:
+            data = json.loads(html_lib.unescape(match.group(1)))
+        except (TypeError, ValueError):
+            continue
+        description = str(data.get("description") or "") if isinstance(data, dict) else ""
+        count = re.search(r"\b(\d[\d ,.]*)\s+(?:items?|songs?|tracks?)\b",
+                          description, re.I)
+        if count:
+            digits = re.sub(r"\D", "", count.group(1))
+            if digits:
+                return int(digits)
+    return None
+
+
+async def spotify_tracklist(url: str, log=print) -> Tuple[str, List[Dict[str, str]]]:
+    playlist_id = _playlist_id(url)
+    if not playlist_id:
+        raise LucidaError("Spotify playlist ID not found in the URL")
+    embed_url = f"https://open.spotify.com/embed/playlist/{playlist_id}"
+    response = await _public_get(embed_url)
+    name, tracks = _spotify_playlist_from_html(response.text)
+    if len(tracks) == 100:
+        public = await _public_get(f"https://open.spotify.com/playlist/{playlist_id}")
+        total = _spotify_total_from_html(public.text)
+        if total and total > len(tracks):
+            raise LucidaError(
+                f"Spotify exposes only the first 100 of {total} titles publicly. "
+                "Export the complete playlist to a text file, then use `playlist-file`."
+            )
+        if total is None:
+            log("  Spotify returned 100 titles; a longer public playlist may be truncated")
+    return name, tracks
+
+
+def _deezer_playlist_from_obj(data: Any) -> Tuple[str, List[Dict[str, str]], str]:
+    if not isinstance(data, dict):
+        raise LucidaError("Deezer returned unreadable playlist data")
+    if isinstance(data.get("error"), dict):
+        message = data["error"].get("message") or "playlist unavailable"
+        raise LucidaError(f"Deezer: {message}")
+    name = " ".join(str(data.get("title") or "").split())
+    block = data.get("tracks") if isinstance(data.get("tracks"), dict) else data
+    rows = block.get("data") if isinstance(block, dict) else []
+    tracks: List[Dict[str, str]] = []
+    for item in rows or []:
+        if not isinstance(item, dict):
+            continue
+        title = " ".join(str(item.get("title") or item.get("title_short") or "").split())
+        contributors = (item.get("contributors")
+                        if isinstance(item.get("contributors"), list) else [])
+        artists = [str(artist.get("name") or "").strip() for artist in contributors
+                   if isinstance(artist, dict) and artist.get("name")]
+        primary = item.get("artist") if isinstance(item.get("artist"), dict) else {}
+        artist = ", ".join(dict.fromkeys(artists)) or str(primary.get("name") or "").strip()
+        if title and artist:
+            tracks.append({"title": title, "artist": artist})
+    return name, tracks, str(block.get("next") or "") if isinstance(block, dict) else ""
+
+
+async def deezer_tracklist(url: str, log=print) -> Tuple[str, List[Dict[str, str]]]:
+    playlist_id = _playlist_id(url)
+    if not playlist_id:
+        raise LucidaError("Deezer playlist ID not found in the URL")
+    response = await _public_get(f"https://api.deezer.com/playlist/{playlist_id}")
+    name, tracks, next_url = _deezer_playlist_from_obj(response.json())
+    pages = 1
+    while next_url and pages < 100:
+        response = await _public_get(next_url)
+        _, more, next_url = _deezer_playlist_from_obj(response.json())
+        tracks.extend(more)
+        pages += 1
+    if next_url:
+        log("  Deezer pagination stopped after 100 pages")
+    return name, tracks
+
+
+async def public_playlist_tracklist(url: str, log=print) -> Tuple[str, List[Dict[str, str]]]:
+    source = playlist_source(url)
+    if source == "spotify":
+        return await spotify_tracklist(url, log)
+    if source == "deezer":
+        return await deezer_tracklist(url, log)
+    raise LucidaError("This public playlist source is not supported by the HTTP importer")
 
 
 # --- Apple Music playlist scraping (needs a Playwright page) ----------------

--- a/lucidadl/cli.py
+++ b/lucidadl/cli.py
@@ -15,7 +15,7 @@ import click
 from . import __version__
 from . import api, organize, paths, progress, transcode, utils
 from .api import (LucidaClient, default_country, normalize_service, DOWNSCALE_CHOICES,
-                  is_apple_playlist_url, LUCIDA)
+                  playlist_source, playlist_source_name, LUCIDA)
 from .downloader import preview_tracks, run_batch
 from .models import FailedItem
 from .session import (lucida_context, ensure_cleared, get_page, BrowserClosed,
@@ -560,7 +560,7 @@ def search_cmd(query, service, country, downscale, out, organize_on, jobs,
         _exit_if_failed(result)
 
 
-# --- Apple Music playlist import -------------------------------------------
+# --- public playlist import -------------------------------------------------
 
 def _render_playlist(collection: str, tracks: list, dry_run: bool) -> None:
     """Compact, pretty playlist summary: a rich table for --dry-run, a single header
@@ -717,42 +717,52 @@ async def _download_playlist_items(collection: str, items: List[str], source: st
 async def _playlist(url, dry_run, service, country, downscale, out, hidden,
                      jobs, organize_on=True, to_fmt=None, bitrate=None, keep_orig=False,
                      force=False, check_matches=False) -> bool:
-    if not is_apple_playlist_url(url):
-        click.secho("Only public Apple Music playlist links are supported.", fg="red")
+    source = playlist_source(url)
+    if not source:
+        click.secho(
+            "Paste a public Apple Music, Spotify, or Deezer playlist link.", fg="red"
+        )
         return False
 
     name, tracks = "", []
-
-    async def _scrape(headless: bool):
-        # Apple Music is NOT behind Cloudflare, so the tracklist can be scraped headless
-        # (no visible window). `hidden` only matters for the headed fallback.
-        async with lucida_context(headless=headless,
-                                  hidden=(hidden and not headless)) as ctx:
-            page = await get_page(ctx)
-            return await api.playlist_tracklist(page, url, click.echo)
-
     try:
-        click.echo("Reading the playlist (headless browser)…")
-        try:
-            name, tracks = await _scrape(headless=True)
-        except BrowserClosed:
-            raise
-        except Exception as e:
-            click.secho(f"  headless: {e}", fg="yellow")  # fall through to the headed retry
-        if not tracks:
-            click.secho("Headless unsuccessful — retrying with a visible window…",
-                        fg="yellow")
-            name, tracks = await _scrape(headless=False)
+        if source == "apple":
+            async def _scrape(headless: bool):
+                # Apple Music uses a dynamic page, so it still needs Playwright. `hidden`
+                # only matters for the visible fallback.
+                async with lucida_context(headless=headless,
+                                          hidden=(hidden and not headless)) as ctx:
+                    page = await get_page(ctx)
+                    return await api.playlist_tracklist(page, url, click.echo)
+
+            click.echo("Reading the Apple Music playlist (headless browser)…")
+            try:
+                name, tracks = await _scrape(headless=True)
+            except BrowserClosed:
+                raise
+            except Exception as e:
+                click.secho(f"  headless: {e}", fg="yellow")
+            if not tracks:
+                click.secho("Headless unsuccessful — retrying with a visible window…",
+                            fg="yellow")
+                name, tracks = await _scrape(headless=False)
+        else:
+            click.echo(f"Reading the public {playlist_source_name(source)} playlist…")
+            name, tracks = await api.public_playlist_tracklist(url, click.echo)
     except BrowserClosed:
         click.secho(_CLOSED_HINT, fg="red")
         return False
     except Exception as e:
-        click.secho(f"✗ playlist extraction: {e}", fg="red")
+        click.secho(f"✗ {playlist_source_name(source)} playlist extraction: {e}", fg="red")
         return False
 
     if not tracks:
-        click.secho("No tracks extracted. Diagnostic files were saved in the app data "
-                    "folder; run `lucida config` to see its location.", fg="red")
+        detail = (" Diagnostic files were saved in the app data folder; run `lucida "
+                  "config` to see its location." if source == "apple" else "")
+        click.secho(
+            f"No public tracks were found. The playlist may be empty or private.{detail}",
+            fg="red",
+        )
         return False
 
     collection = name or "Playlist"
@@ -785,7 +795,7 @@ async def _playlist(url, dry_run, service, country, downscale, out, hidden,
 @_service_opts
 def playlist_cmd(url, dry_run, check_matches, service, country, downscale, out, organize_on, jobs,
                  to_fmt, bitrate, keep_orig, force, hidden):
-    """Import a public Apple Music playlist and download its tracks via lucida."""
+    """Import a public Apple Music, Spotify, or Deezer playlist."""
     if dry_run and check_matches:
         raise click.UsageError("Choose either --dry-run or --check, not both.")
     ok = asyncio.run(_playlist(url, dry_run, service, country, downscale, out, hidden,

--- a/lucidadl/downloader.py
+++ b/lucidadl/downloader.py
@@ -62,8 +62,8 @@ async def _resolve_url(client: LucidaClient, line: str, service: str, kind: str,
             items = res.get(bucket) or []
             if not items:
                 continue
-            # The full query keeps its lenient match; broadened variants must match the
-            # artist, so a title-only search can't silently grab the wrong artist.
+            # Automatic matching always checks the primary artist. Broadened variants
+            # request it explicitly too, keeping the intent obvious at the call site.
             url = matching.pick_best(
                 line, items, require_artist=(v_idx > 0),
                 min_score=5.5 if explicit_artist else None,

--- a/lucidadl/matching.py
+++ b/lucidadl/matching.py
@@ -37,6 +37,27 @@ def _split_query(q: str):
     return "", q.strip()
 
 
+def _primary_artist(s: str) -> str:
+    """Return the first credited artist without splitting names containing ``&``."""
+    return re.split(
+        r"\s*(?:,|/| feat\.?| ft\.?| x | vs\.?| with )\s*",
+        s or "", maxsplit=1, flags=re.I,
+    )[0].strip()
+
+
+def _has_unrequested_variant(query: str, item: Dict[str, str]) -> bool:
+    """Reject a clearly labelled alternate version during automatic matching."""
+    title = item.get("title", "")
+    title_tokens = _tokens(title)
+    query_tokens = _tokens(query)
+    if any(token in title_tokens and token not in query_tokens for token in _BAD_TOKENS):
+        return True
+    normalized_title = _norm(title)
+    normalized_query = _norm(query)
+    return any(phrase in normalized_title and phrase not in normalized_query
+               for phrase in _BAD_PHRASES)
+
+
 def score(query: str, item: Dict[str, str]) -> float:
     artist_q, title_q = _split_query(query)
     q_tokens = _tokens(query)
@@ -78,14 +99,21 @@ def score(query: str, item: Dict[str, str]) -> float:
 
 
 def artist_matches(query: str, item: Dict[str, str]) -> bool:
-    """True if the item's artist (or row context) overlaps the query's artist tokens.
-    Used to reject wrong-artist hits when a search was broadened to the title alone."""
+    """True when the first credited artist reasonably matches the requested artist.
+
+    Checking only for any shared token accepted covers where the requested performer was
+    merely a secondary credit. Context remains a fallback for older search responses that
+    do not expose a dedicated artist field.
+    """
     artist_q, _ = _split_query(query)
-    aq = _tokens(artist_q)
+    aq = _tokens(_primary_artist(artist_q))
     if not aq:
         return True  # no artist asked for → nothing to reject
-    pool = _tokens(item.get("artist", "")) | _tokens(item.get("context") or "")
-    return bool(aq & pool)
+    artist = item.get("artist", "")
+    if artist:
+        candidate = _tokens(_primary_artist(artist))
+        return len(aq & candidate) / len(aq) >= 0.6
+    return bool(aq & _tokens(item.get("context") or ""))
 
 
 def pick_best(query: str, items: List[Dict[str, str]],
@@ -98,11 +126,17 @@ def pick_best(query: str, items: List[Dict[str, str]],
     if not items:
         return None
     pool = items
-    if require_artist:
+    automatic = min_score is not None
+    artist_q, _ = _split_query(query)
+    if require_artist or (automatic and artist_q):
         matched = [it for it in items if artist_matches(query, it)]
         if not matched:
             return None
         pool = matched
+    if automatic:
+        pool = [it for it in pool if not _has_unrequested_variant(query, it)]
+        if not pool:
+            return None
     ranked = sorted(enumerate(pool), key=lambda pair: score(query, pair[1]), reverse=True)
     best_i, best_item = ranked[0]
     best_s = score(query, best_item)

--- a/lucidadl/tui.py
+++ b/lucidadl/tui.py
@@ -165,7 +165,7 @@ def run() -> None:
             menu.append(Choice("✨  Set up lucidadl (recommended)", "onboarding"))
         menu += [
             Choice("⬇   Download music", "download"),
-            Choice("🎶  Playlists — Apple Music or an edited list", "playlist"),
+            Choice("🎶  Playlists — streaming link or an edited list", "playlist"),
             Choice("📄  Download from a .txt file", "batch"),
         ]
         failed = cli._read_failed()
@@ -247,14 +247,17 @@ def _dispatch(action, s, console, cli, questionary) -> bool:
     if action == "playlist":
         from questionary import Choice
         source = questionary.select("Playlist source:", choices=[
-            Choice("🍎  Public Apple Music link", "apple"),
+            Choice("🔗  Public streaming link", "remote"),
             Choice("📄  Edited .txt list", "file"),
             Choice("← Back", "back"),
         ]).ask()
         if source in (None, "back"):
             return False
-        if source == "apple":
-            url = _ask_text(questionary, "Apple Music playlist URL:", "(empty = back)")
+        if source == "remote":
+            url = _ask_text(
+                questionary, "Playlist URL:",
+                "(public Apple Music, Spotify or Deezer link; empty = back)",
+            )
             if not url:
                 return False
         else:
@@ -280,14 +283,14 @@ def _dispatch(action, s, console, cli, questionary) -> bool:
             Choice("⬇   Download or resume this playlist", "download"),
             Choice("✓   Check every automatic match first", "check"),
             *([Choice("📄  Only extract and save the track list", "list")]
-              if source == "apple" else []),
+              if source == "remote" else []),
             Choice("← Back", "back"),
         ]).ask()
         if mode in (None, "back"):
             return False
-        if not (source == "apple" and mode == "list"):
+        if not (source == "remote" and mode == "list"):
             _warn_browser()
-        if source == "apple":
+        if source == "remote":
             asyncio.run(cli._playlist(
                 url, mode == "list", s["service"], None, "original", out,
                 hidden=False, jobs=s["jobs"], organize_on=True, to_fmt=s["to"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,16 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lucidadl"
-version = "1.2.0"
-description = "Fast, parallel CLI music downloader for lucida.to with resilient Apple Music playlist imports."
+version = "1.3.0"
+description = "Fast, parallel CLI music downloader for lucida.to with resilient public playlist imports."
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
 authors = [{ name = "Jude-A" }]
-keywords = ["music", "downloader", "lucida", "qobuz", "amazon", "apple-music", "playlist", "flac", "cli", "tui"]
+keywords = [
+    "music", "downloader", "lucida", "qobuz", "amazon", "apple-music",
+    "spotify", "deezer", "playlist", "flac", "cli", "tui",
+]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",

--- a/selftest.py
+++ b/selftest.py
@@ -5,7 +5,9 @@ import asyncio as _aio
 from lucidadl import utils, matching
 from lucidadl.api import (
     LucidaClient, normalize_service, default_country, _long, _apple_tracks_from_obj,
-    _apple_playlist_from_scripts, is_apple_playlist_url, DOWNSCALE_CHOICES,
+    _apple_playlist_from_scripts, is_apple_playlist_url, playlist_source,
+    _spotify_playlist_from_html, _spotify_total_from_html,
+    _deezer_playlist_from_obj, DOWNSCALE_CHOICES,
 )
 from lucidadl.models import FailedItem
 
@@ -42,6 +44,11 @@ check("Apple URL validation accepts playlists only",
       is_apple_playlist_url("https://music.apple.com/fr/playlist/mix/pl.123")
       and not is_apple_playlist_url("https://music.apple.com/fr/album/record/123")
       and not is_apple_playlist_url("https://example.com/playlist/mix/pl.123"))
+check("public playlist source detection",
+      playlist_source("https://music.apple.com/fr/playlist/mix/pl.123") == "apple"
+      and playlist_source("https://open.spotify.com/playlist/abc?si=share") == "spotify"
+      and playlist_source("https://www.deezer.com/fr/playlist/123") == "deezer"
+      and playlist_source("https://open.spotify.com/album/abc") == "")
 
 # long path (Windows)
 import os as _os
@@ -82,6 +89,47 @@ _duplicate_name, _duplicate_tracks = _apple_playlist_from_scripts([
     __import__("json").dumps(_duplicate_sample)])
 check("apple structured extractor preserves intentional duplicate positions",
       _duplicate_name == "Loop" and len(_duplicate_tracks) == 2)
+
+# Spotify and Deezer importers parse public metadata only; downloads still use lucida.
+_spotify_obj = {
+    "props": {"pageProps": {"state": {"data": {"entity": {
+        "type": "playlist", "name": "My Spotify Mix", "trackList": [
+            {"entityType": "track", "title": "One", "subtitle": "Artist\xa0A"},
+            {"entityType": "episode", "title": "Podcast", "subtitle": "Host"},
+            {"entityType": "track", "title": "One", "subtitle": "Artist\xa0A"},
+        ],
+    }}}}},
+}
+_spotify_html = ('<script id="__NEXT_DATA__" type="application/json">'
+                 + __import__("json").dumps(_spotify_obj) + '</script>')
+_spotify_name, _spotify_tracks = _spotify_playlist_from_html(_spotify_html)
+check("spotify extractor keeps order/duplicates and skips episodes",
+      _spotify_name == "My Spotify Mix"
+      and _spotify_tracks == [
+          {"title": "One", "artist": "Artist A"},
+          {"title": "One", "artist": "Artist A"},
+      ])
+_spotify_ld = ('<script type="application/ld+json">'
+               + __import__("json").dumps({
+                   "description": "Playlist · Top Hits 2026 · 198 items · 2 saves"})
+               + '</script>')
+check("spotify extractor detects playlists beyond the public 100-item window",
+      _spotify_total_from_html(_spotify_ld) == 198)
+
+_deezer_name, _deezer_tracks, _deezer_next = _deezer_playlist_from_obj({
+    "title": "My Deezer Mix",
+    "tracks": {"data": [
+        {"title": "First", "artist": {"name": "Primary"},
+         "contributors": [{"name": "Primary"}, {"name": "Guest"}]},
+        {"title": "Again", "artist": {"name": "Primary"}},
+    ], "next": "https://api.deezer.com/next"},
+})
+check("deezer extractor keeps order, contributors and pagination",
+      _deezer_name == "My Deezer Mix"
+      and _deezer_tracks == [
+          {"title": "First", "artist": "Primary, Guest"},
+          {"title": "Again", "artist": "Primary"},
+      ] and _deezer_next.endswith("/next"))
 
 # State dedup
 import tempfile
@@ -332,6 +380,23 @@ check("matching: automatic mode rejects tied editions",
                          [{"url": "a", "title": "Song", "artist": "Artist"},
                           {"url": "b", "title": "Song", "artist": "Artist"}],
                          min_score=5.5, min_margin=0.25) is None)
+check("matching: automatic mode rejects a secondary-artist cover",
+      matching.pick_best(
+          "Red Hot Chili Peppers - Under the Bridge",
+          [{"url": "cover", "title": "Under The Bridge",
+            "artist": "Rhythms Del Mundo, Red Hot Chili Peppers"}],
+          min_score=5.5, min_margin=0.25) is None)
+check("matching: automatic mode rejects an unrequested sped-up version",
+      matching.pick_best(
+          "Manu Chao - Bongo Bong",
+          [{"url": "sped", "title": "Bongo Bong - Sped Up (Manu Chao)",
+            "artist": "Manu Chao, spedup trends"}],
+          min_score=5.5, min_margin=0.25) is None)
+check("matching: automatic mode accepts a matching primary artist",
+      matching.pick_best(
+          "La Fine Equipe, Saneyes - Lying With You",
+          [{"url": "right", "title": "Lying With You", "artist": "La Fine Equipe"}],
+          min_score=5.5, min_margin=0.25) == "right")
 
 # resolver query variants (specific -> loose) + artist-gated broadening
 from lucidadl.downloader import _query_variants as _qv
@@ -398,7 +463,7 @@ check("require_artist returns None when no artist matches (no wrong download)",
       matching.pick_best("Sinyo' - Enfant Perdu", _only_wrong, require_artist=True) is None)
 check("require_artist off -> legacy best-anyway behavior",
       matching.pick_best("Sinyo' - Enfant Perdu", _only_wrong) == "w")
-check("artist_matches token overlap",
+check("artist_matches checks the primary artist",
       matching.artist_matches("Sinyo' - Enfant Perdu", {"artist": "Sinyo"}) is True
       and matching.artist_matches("Sinyo' - Enfant Perdu", {"artist": "Other"}) is False)
 
@@ -602,6 +667,22 @@ with _patch.object(_cli, "lucida_context") as _playlist_browser:
 check("playlist: unsupported links fail before opening a browser",
       not _unsupported_ok and not _playlist_browser.called)
 
+_remote_list = _os.path.join(tempfile.gettempdir(), "lucidadl_remote_playlist.txt")
+with _patch.object(_cli.api, "public_playlist_tracklist", _AsyncMock(return_value=(
+        "Public Mix", [{"artist": "Artist", "title": "Song"}]))), \
+     _patch.object(_cli, "PLAYLIST_TEXT_PATH", _remote_list), \
+     _patch.object(_cli, "lucida_context") as _remote_browser:
+    with _ctxlib.redirect_stdout(_io.StringIO()):
+        _remote_ok = _aio.run(_cli._playlist(
+            "https://open.spotify.com/playlist/abc", True, "qobuz", None,
+            "original", tempfile.gettempdir(), False, 3))
+check("playlist: Spotify dry-run does not launch a browser",
+      _remote_ok and not _remote_browser.called and _os.path.exists(_remote_list))
+try:
+    _os.remove(_remote_list)
+except OSError:
+    pass
+
 check("playlist: failures before download retain recovery context",
       _cli._failed_result(
           ["Artist - One", "Artist - Two"], "track", "My Mix", ["01", "02"]
@@ -632,7 +713,7 @@ _help = _runner.invoke(_cli.cli, ["--help"])
 check("cli: developer debug command is hidden", "  debug " not in _help.output)
 _version = _runner.invoke(_cli.cli, ["--version"])
 check("cli: source version matches release metadata",
-      _version.exit_code == 0 and "1.2.0" in _version.output)
+      _version.exit_code == 0 and "1.3.0" in _version.output)
 
 print()
 if fails:


### PR DESCRIPTION
## What changes
- import public Spotify and Deezer playlists through the existing playlist workflow
- keep order, duplicates, match checking, editable lists, downloads, and resume behavior
- prevent silent truncation when Spotify declares more than its 100 publicly exposed entries
- reject clearly labelled alternate versions and secondary-artist covers during automatic matching
- refresh the CLI, terminal menu, README, changelog, and contributor guidance for the shared flow

## Validation
- full offline self-test suite
- package build and metadata check
- clean wheel import and self-tests
- live Spotify dry-run and match check with a 19-track user playlist
- live Deezer dry-run with a 100-track public playlist
- live Spotify over-100 guard