### PR TITLE
Support Spotify playlists beyond 100 tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-09-03
+
+### Fixed
+- Spotify playlists longer than 100 items now switch to the complete public web view and
+  read every position instead of stopping at the public player's initial window.
+
 ## [1.3.0] - 2026-09-03
 
 ### Added
@@ -139,7 +145,8 @@ First public release.
 - **Fixed, configurable download directory** (`~/Downloads/music` by default;
   `lucida config --music`, or the `LUCIDADL_MUSIC` env var).
 
-[Unreleased]: https://github.com/Jude-A/lucidadl/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/Jude-A/lucidadl/compare/v1.3.1...HEAD
+[1.3.1]: https://github.com/Jude-A/lucidadl/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/Jude-A/lucidadl/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/Jude-A/lucidadl/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/Jude-A/lucidadl/compare/v1.0.0...v1.1.0

--- a/README.md
+++ b/README.md
@@ -133,10 +133,10 @@ settings, and track numbers. Existing files are skipped, and the `.m3u8` is rebu
 the run finishes. Repeating the same song at two different positions is supported.
 
 Only public playlists are read: lucidadl does not connect to or modify an Apple Music,
-Spotify, or Deezer account. Spotify's public player exposes at most 100 items; when the
-declared playlist is longer, lucidadl stops with an explicit message instead of importing
-an incomplete list. Cross-service playlist translation and account authorization remain
-the responsibility of a separate companion project.
+Spotify, or Deezer account. Short Spotify playlists use the fast public player; longer
+ones automatically switch to a headless browser and scroll Spotify's public list until
+every position has been read. Cross-service playlist translation and account
+authorization remain the responsibility of a separate companion project.
 
 ## Interactive menu
 

--- a/lucidadl/__init__.py
+++ b/lucidadl/__init__.py
@@ -1,3 +1,3 @@
 """lucidadl — automated music downloader driving lucida.to through a real browser."""
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"

--- a/lucidadl/api.py
+++ b/lucidadl/api.py
@@ -9,8 +9,9 @@ Flow (all httpx, like the Rust jelni client):
   start_download(track)   -> POST /api/load -> {handoff, server}
   run_job(handoff,server) -> poll <server>.lucida.to (Cloudflare-free) -> stream file
 
-Public Spotify and Deezer playlist metadata is read directly over HTTP. Apple Music
-still needs a Playwright page because its public track list is rendered dynamically.
+Public Spotify and Deezer playlist metadata is normally read directly over HTTP.
+Apple Music and Spotify playlists beyond the public player's first window use a
+Playwright page because their complete track lists are rendered dynamically.
 """
 
 from __future__ import annotations
@@ -56,6 +57,16 @@ _EXT_BY_CTYPE = {
 
 class LucidaError(RuntimeError):
     pass
+
+
+class SpotifyPlaylistWindow(LucidaError):
+    """The fast public player exposed only its first 100 playlist items."""
+
+    def __init__(self, name: str, total: int):
+        self.name = name
+        self.total = total
+        detail = f"100 of {total} titles" if total else "its first 100 titles"
+        super().__init__(f"Spotify's public player exposed {detail}")
 
 
 def _retry_delay(response, attempt: int) -> int:
@@ -520,12 +531,126 @@ async def spotify_tracklist(url: str, log=print) -> Tuple[str, List[Dict[str, st
         public = await _public_get(f"https://open.spotify.com/playlist/{playlist_id}")
         total = _spotify_total_from_html(public.text)
         if total and total > len(tracks):
-            raise LucidaError(
-                f"Spotify exposes only the first 100 of {total} titles publicly. "
-                "Export the complete playlist to a text file, then use `playlist-file`."
-            )
+            raise SpotifyPlaylistWindow(name, total)
         if total is None:
-            log("  Spotify returned 100 titles; a longer public playlist may be truncated")
+            raise SpotifyPlaylistWindow(name, 0)
+    return name, tracks
+
+
+_SPOTIFY_VISIBLE_ROWS_JS = """() => {
+    const grid = document.querySelector('[data-testid="playlist-tracklist"][role="grid"]');
+    if (!grid) return [];
+    return Array.from(grid.querySelectorAll('[role="row"][aria-rowindex]')).map(row => {
+        const position = Number(row.getAttribute('aria-rowindex')) - 1;
+        const track = row.querySelector(
+            'a[data-testid="internal-track-link"], a[href*="/track/"]'
+        );
+        const episode = row.querySelector('a[href*="/episode/"]');
+        const artists = Array.from(row.querySelectorAll(
+            '[role="gridcell"][aria-colindex="2"] a[href*="/artist/"]'
+        )).map(node => (node.textContent || '').trim()).filter(Boolean);
+        return {
+            position,
+            kind: track ? 'track' : (episode ? 'episode' : 'pending'),
+            title: track ? (track.textContent || '').trim() : '',
+            artist: [...new Set(artists)].join(', '),
+        };
+    });
+}"""
+
+_SPOTIFY_SCROLL_JS = """target => {
+    const grid = document.querySelector('[data-testid="playlist-tracklist"][role="grid"]');
+    if (!grid) return null;
+    let node = grid.parentElement;
+    while (node && !(node.scrollHeight > node.clientHeight + 50 &&
+           ['auto', 'scroll'].includes(getComputedStyle(node).overflowY))) {
+        node = node.parentElement;
+    }
+    if (!node) return null;
+    node.scrollTop = Math.min(target, node.scrollHeight - node.clientHeight);
+    node.dispatchEvent(new Event('scroll', {bubbles: true}));
+    return {top: node.scrollTop, height: node.scrollHeight, viewport: node.clientHeight};
+}"""
+
+
+async def spotify_browser_tracklist(page, url: str, name: str, total: int,
+                                     log=print) -> Tuple[str, List[Dict[str, str]]]:
+    """Read a long public playlist by scrolling Spotify's own paginated web view."""
+    await page.goto(url, wait_until="domcontentloaded", timeout=60_000)
+    try:
+        await page.wait_for_selector(
+            '[data-testid="playlist-tracklist"] a[href*="/track/"]', timeout=30_000
+        )
+        await page.wait_for_function("""() => {
+            const grid = document.querySelector(
+                '[data-testid="playlist-tracklist"][role="grid"]'
+            );
+            let node = grid && grid.parentElement;
+            while (node && !(node.scrollHeight > node.clientHeight + 50 &&
+                   ['auto', 'scroll'].includes(getComputedStyle(node).overflowY))) {
+                node = node.parentElement;
+            }
+            return Boolean(node);
+        }""", timeout=30_000)
+    except Exception as exc:
+        raise LucidaError("Spotify's public track list did not become available") from exc
+
+    try:
+        rendered_count = await page.locator(
+            '[data-testid="playlist-tracklist"]'
+        ).get_attribute("aria-rowcount")
+        rendered_total = max(0, int(rendered_count or 0) - 1)
+    except (TypeError, ValueError):
+        rendered_total = 0
+    if rendered_total:
+        total = rendered_total
+    if not total:
+        raise LucidaError("Spotify's public playlist size could not be determined")
+
+    found: Dict[int, Dict[str, str]] = {}
+    observed = set()
+    target = 0
+    last_top = -1
+    stagnant = 0
+    reported = 0
+    while len(observed) < total and stagnant < 5:
+        rows = await page.evaluate(_SPOTIFY_VISIBLE_ROWS_JS)
+        for row in rows or []:
+            position = row.get("position")
+            if not isinstance(position, int) or position < 1 or position > total:
+                continue
+            if row.get("kind") not in ("track", "episode"):
+                continue
+            observed.add(position)
+            if row.get("kind") == "track" and row.get("title") and row.get("artist"):
+                found[position] = {
+                    "title": " ".join(str(row["title"]).split()),
+                    "artist": " ".join(str(row["artist"]).split()),
+                }
+        metrics = await page.evaluate(_SPOTIFY_SCROLL_JS, target)
+        if not metrics:
+            raise LucidaError("Spotify's public playlist could not be scrolled")
+        top = int(metrics.get("top") or 0)
+        if top == last_top:
+            stagnant += 1
+        else:
+            stagnant = 0
+            last_top = top
+        if len(observed) >= reported + 100:
+            reported = len(observed) // 100 * 100
+            log(f"  read {len(observed)} of {total} Spotify positions")
+        step = max(400, int(metrics.get("viewport") or 700) * 3 // 4)
+        target = min(target + step,
+                     int(metrics.get("height") or 0) - int(metrics.get("viewport") or 0))
+        await page.wait_for_timeout(250)
+
+    if len(observed) < total:
+        raise LucidaError(
+            f"Spotify exposed only {len(observed)} of {total} playlist positions"
+        )
+    tracks = [found[position] for position in sorted(found)]
+    if not tracks:
+        raise LucidaError("Spotify's public playlist contained no music tracks")
     return name, tracks
 
 

--- a/lucidadl/cli.py
+++ b/lucidadl/cli.py
@@ -748,7 +748,17 @@ async def _playlist(url, dry_run, service, country, downscale, out, hidden,
                 name, tracks = await _scrape(headless=False)
         else:
             click.echo(f"Reading the public {playlist_source_name(source)} playlist…")
-            name, tracks = await api.public_playlist_tracklist(url, click.echo)
+            try:
+                name, tracks = await api.public_playlist_tracklist(url, click.echo)
+            except api.SpotifyPlaylistWindow as limited:
+                detail = (f"reports {limited.total} titles" if limited.total
+                          else "returned its 100-item public window")
+                click.echo(f"Spotify {detail} — reading the full list in a headless browser…")
+                async with lucida_context(headless=True) as ctx:
+                    page = await get_page(ctx)
+                    name, tracks = await api.spotify_browser_tracklist(
+                        page, url, limited.name, limited.total, click.echo
+                    )
     except BrowserClosed:
         click.secho(_CLOSED_HINT, fg="red")
         return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lucidadl"
-version = "1.3.0"
+version = "1.3.1"
 description = "Fast, parallel CLI music downloader for lucida.to with resilient public playlist imports."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/selftest.py
+++ b/selftest.py
@@ -683,6 +683,38 @@ try:
 except OSError:
     pass
 
+class _FakeBrowserContext:
+    async def __aenter__(self):
+        return object()
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+_long_list = _os.path.join(tempfile.gettempdir(), "lucidadl_long_spotify.txt")
+with _patch.object(
+        _cli.api, "public_playlist_tracklist",
+        _AsyncMock(side_effect=_cli.api.SpotifyPlaylistWindow("Long Mix", 150))), \
+     _patch.object(_cli, "PLAYLIST_TEXT_PATH", _long_list), \
+     _patch.object(_cli, "lucida_context", return_value=_FakeBrowserContext()) as _long_ctx, \
+     _patch.object(_cli, "get_page", _AsyncMock(return_value=object())), \
+     _patch.object(
+         _cli.api, "spotify_browser_tracklist",
+         _AsyncMock(return_value=(
+             "Long Mix", [{"artist": "Artist", "title": "Song"}] * 150
+         )),
+     ) as _long_reader:
+    with _ctxlib.redirect_stdout(_io.StringIO()):
+        _long_ok = _aio.run(_cli._playlist(
+            "https://open.spotify.com/playlist/long", True, "qobuz", None,
+            "original", tempfile.gettempdir(), False, 3))
+check("playlist: long Spotify list switches to the browser reader",
+      _long_ok and _long_ctx.called and _long_reader.await_count == 1)
+try:
+    _os.remove(_long_list)
+except OSError:
+    pass
+
 check("playlist: failures before download retain recovery context",
       _cli._failed_result(
           ["Artist - One", "Artist - Two"], "track", "My Mix", ["01", "02"]
@@ -713,7 +745,7 @@ _help = _runner.invoke(_cli.cli, ["--help"])
 check("cli: developer debug command is hidden", "  debug " not in _help.output)
 _version = _runner.invoke(_cli.cli, ["--version"])
 check("cli: source version matches release metadata",
-      _version.exit_code == 0 and "1.3.0" in _version.output)
+      _version.exit_code == 0 and "1.3.1" in _version.output)
 
 print()
 if fails:


### PR DESCRIPTION
## What changes
- keep the fast public-player import for short Spotify playlists
- automatically switch long playlists to Spotify's complete public web view
- scroll the virtualized list and preserve every ordered track position
- continue to skip podcast episodes in the music-only workflow
- publish the behavior as version 1.3.1

## Validation
- full offline self-test suite
- package build and metadata check
- live end-to-end dry-run of a 500-track public Spotify playlist
- verified first, 100th, and final extracted positions